### PR TITLE
Remove dual directorship.

### DIFF
--- a/articles.tex
+++ b/articles.tex
@@ -425,26 +425,10 @@ However, the Chairman and at least two-thirds of the Voting Members must be pres
 \end{enumerate}
 
 \asection{Selection}
-\asubsection{Dual Directorship}
-Social and Research and Development are the only voting Executive Board positions that allow for Dual Directorship.
-If two candidates elect to run as a Dual Directorship, their names are placed together on a single line of the election ballot.
-If they are also nominated as a normal directorship or as a dual directorship with another House member, their votes are not cumulative.
-Each different nomination must be a separate entry on the election ballot. 
-Non-voting Executive Board positions (i.e. Ad-Hoc Directors) are not restricted to single or dual directorship.
-
-The following special cases cover the operation of a dual directorship:
-\begin{itemize}
-	\item If one of the members in a dual directorship resigns the directorship, or for any other reason ends the term of office, the other member in the dual directorship must also step down and the office becomes vacated.
-		The vacated office is then handled like any other vacated office; see \ref{Resignations}.
-	\item During an official Executive Board Vote, each dual directorship member's vote counts for one-half vote in the tallying of votes.
-		The members of the dual directorship need not vote the same way in a vote.
-	\item A member of a dual directorship may not hold any other Executive Board position.
-	\item When attendance requirements call for the dual directorship position to be present, both dual directorship members are to fulfill the requirements.
-\end{itemize}
 \asubsection{Selection of the Chairman, Evaluations Director, Social Director(s), Financial Director, House Improvements Director, House History Director, Research and Development Director(s)}
 \begin{enumerate}
 	\item The opening of the Executive Board position(s) is announced at a House meeting and nominations for the position are taken for a minimum of a seventy-two hour period.
-		Any House member may nominate any eligible member or pair of members where appropriate for a Directorship.
+		Any House member may nominate any eligible member for a Directorship.
 	\item The candidates meeting the qualifications of the office they were nominated for, will be notified of their nomination.
 		Each candidate is given a minimum of twenty-four hour period to accept or decline the nomination.
 		A list of all nominees who have accepted their nominations will be posted shortly thereafter.


### PR DESCRIPTION
Check one:
- [X] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Remove dual directorship from the Constitution. Please look for other places in the document that may refer to the possibility of having dual directors.

To be announced on April 17th, 2016. To be voted on April 24, 2016.
