### PR TITLE
Executive Board Confidentiality and Safe Environment

### DIFF
--- a/articles.tex
+++ b/articles.tex
@@ -303,7 +303,7 @@ However, the Chairman and at least two-thirds of the Voting Members must be pres
 	\item To act as a Judicial Board as defined in \ref{Judicial}.
 	\item To review major projects, as defined in \ref{Expectations of House Members},  presented to them by the Evaluations director.
 	\item To make the final vote regarding conditionals and appeals as defined in \ref{Membership Evaluation}.
-	\item To respect the privacy of House members confiding in the Executive Board, barring situations related to endangerment of oneself or others or in the case of a Judicial Board.
+	\item To respect the privacy of House members confiding in the Executive Board, barring situations related to endangerment of oneself or others, sexual assault, or in the case of a Judicial Board.
 	\item To publish a document at the end of each semester to all Members stating House’s accomplishments of that semester.
 	\item To review and update the Constitution at the end of each standard operating session, as defined in \ref{Standard Operating Session}.The constitution should remain up to date with current practices.
 \end{enumerate}

--- a/articles.tex
+++ b/articles.tex
@@ -303,6 +303,8 @@ However, the Chairman and at least two-thirds of the Voting Members must be pres
 	\item To act as a Judicial Board as defined in \ref{Judicial}.
 	\item To review major projects, as defined in \ref{Expectations of House Members},  presented to them by the Evaluations director.
 	\item To make the final vote regarding conditionals and appeals as defined in \ref{Membership Evaluation}.
+	\item To proactively maintain a safe and welcoming enviornment to House members.
+	\item To respect the privacy of House members who confide in confidence barring circumstances that allude endangerment of ones self or others.
 	\item To publish a document at the end of each semester to all Members stating House’s accomplishments of that semester.
 	\item To review and update the Constitution at the end of each standard operating session, as defined in \ref{Standard Operating Session}.The constitution should remain up to date with current practices.
 \end{enumerate}

--- a/articles.tex
+++ b/articles.tex
@@ -303,8 +303,7 @@ However, the Chairman and at least two-thirds of the Voting Members must be pres
 	\item To act as a Judicial Board as defined in \ref{Judicial}.
 	\item To review major projects, as defined in \ref{Expectations of House Members},  presented to them by the Evaluations director.
 	\item To make the final vote regarding conditionals and appeals as defined in \ref{Membership Evaluation}.
-	\item To proactively maintain a safe and welcoming enviornment to House members.
-	\item To respect the privacy of House members who confide in confidence barring circumstances that allude endangerment of ones self or others.
+	\item To respect the privacy of House members who confide in confidence barring circumstances that allude endangerment of ones self or others or in the case of a Judicial Board.
 	\item To publish a document at the end of each semester to all Members stating House’s accomplishments of that semester.
 	\item To review and update the Constitution at the end of each standard operating session, as defined in \ref{Standard Operating Session}.The constitution should remain up to date with current practices.
 \end{enumerate}

--- a/articles.tex
+++ b/articles.tex
@@ -303,7 +303,7 @@ However, the Chairman and at least two-thirds of the Voting Members must be pres
 	\item To act as a Judicial Board as defined in \ref{Judicial}.
 	\item To review major projects, as defined in \ref{Expectations of House Members},  presented to them by the Evaluations director.
 	\item To make the final vote regarding conditionals and appeals as defined in \ref{Membership Evaluation}.
-	\item To respect the privacy of House members who confide in confidence barring circumstances that allude endangerment of ones self or others or in the case of a Judicial Board.
+	\item To respect the privacy of House members confiding in the Executive Board, barring situations related to endangerment of oneself or others or in the case of a Judicial Board.
 	\item To publish a document at the end of each semester to all Members stating House’s accomplishments of that semester.
 	\item To review and update the Constitution at the end of each standard operating session, as defined in \ref{Standard Operating Session}.The constitution should remain up to date with current practices.
 \end{enumerate}


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [x] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

Adds keeping confidentiality as an Executive Board responsibility when a House member requests for something to be kept private, except in cases where there is a potential for harm to themselves or others. Also, adds a responsibility for Executive Board to proactively maintain a safe environment for its members

To be announced on April 17th, 2016. To be voted on April 24, 2016.