### PR TITLE
Resolving grammar problems in Evaluations Processes

### DIFF
--- a/bylaws.tex
+++ b/bylaws.tex
@@ -251,7 +251,7 @@ Additional Note: No hazing shall occur at any time during the Selection Process 
 \bsection{Evaluations Processes}
 During the academic year, a House member is evaluated by the Membership Evaluation.
 The Membership Evaluation is responsible for determining those individuals who will have the option to continue Active Membership in the following year.
-Semi-Annual Evaluations Meetings are open only to all current Active Members.
+Semi-Annual Evaluations Meetings are open only to current Active Members.
 All Executive Board members are expected to attend the Semi-Annual Evaluations Meetings to assist in the evaluations of House members.
 \\* \\*
 At the beginning of any Evaluation Process listed herein, the Evaluations Director must read the sections of the Computer Science House Constitution and By-Laws used during the respective Evaluation Process.

--- a/bylaws.tex
+++ b/bylaws.tex
@@ -262,7 +262,7 @@ All members may notify the evaluations director before the end of the academic y
 The Membership Evaluation process occurs once per academic year. It is performed as part of the Evaluation Process that takes place during the spring semester to comply with RIT Housing deadlines.
 \bsubsubsection{Voting} 
 A quorum of members, on a member by member basis, ensures that each Active Member has met the minimum requirements in order to continue as an Active Member in the following year.
-All Active Members will be held to the requirements and evaluated unless they received an exemption from the Executive Board prior to the event.
+All Active Members will be held to the requirements and evaluated unless they have received an exemption from the Executive Board prior to the event.
 These requirements are detailed in Article V under expectations for each category of membership.
 These requirements must be completed before the Membership Evaluation occurs.
 A secret Simple Majority vote with a quorum of two-thirds of the Total Number of Possible Votes is required for the evaluation to be valid.

--- a/bylaws.tex
+++ b/bylaws.tex
@@ -269,7 +269,7 @@ A secret Simple Majority vote with a quorum of two-thirds of the Total Number of
 Neither absentee nor proxy votes are allowed.
 House may choose any of the Outcomes for each member.
 \bsubsubsection{Outcomes}
-Members who receive a pass have the option to participate as an Active Member in the following the year and remain on the upcoming roster if applicable.
+Members who receive a pass have the option to participate as an Active Member in the following year and remain on the upcoming roster if applicable.
 \\* \\*
 If a member fails and has never passed a Membership Evaluation in the past, their membership will be revoked immediately.
 If the member has previously passed a Membership Evaluation they will move to Alumni Membership status at the end of the Standard Operating Session (\ref{Alumni Membership Selection}).

--- a/bylaws.tex
+++ b/bylaws.tex
@@ -261,7 +261,7 @@ All members may notify the evaluations director before the end of the academic y
 \bsubsection{Membership Evaluation}
 The Membership Evaluation process occurs once per academic year. It is performed as part of the Evaluation Process that takes place during the spring semester to comply with RIT Housing deadlines.
 \bsubsubsection{Voting} 
-A quorum of members, on a member by member basis, ensures that each Active member has met the minimum requirements in order to continue as an Active member in the following year.
+A quorum of members, on a member by member basis, ensures that each Active Member has met the minimum requirements in order to continue as an Active Member in the following year.
 All Active Members will be held to the requirements and evaluated unless they received an exemption from the Executive Board prior to the event.
 These requirements are detailed in Article V under expectations for each category of membership.
 These requirements must be completed before the Membership Evaluation occurs.

--- a/bylaws.tex
+++ b/bylaws.tex
@@ -271,8 +271,8 @@ House may choose any of the Outcomes for each member.
 \bsubsubsection{Outcomes}
 Members who receive a pass have the option participate as an Active Member in the following the year and remain on the upcoming roster if applicable.
 \\* \\*
-If a member fails and has never passed an Membership Evaluation in the past, their membership will be revoked immediately.
-If the member has previously passed an Membership Evaluation they will move to Alumni Membership status at the end of the Standard Operating Session (\ref{Alumni Membership Selection}).
+If a member fails and has never passed a Membership Evaluation in the past, their membership will be revoked immediately.
+If the member has previously passed a Membership Evaluation they will move to Alumni Membership status at the end of the Standard Operating Session (\ref{Alumni Membership Selection}).
 In either case, the member forfeits their ability to be included on the following year’s roster.
 \\* \\*
 A member may be given a conditional to complete as a means of making up for missing requirements.

--- a/bylaws.tex
+++ b/bylaws.tex
@@ -269,7 +269,7 @@ A secret Simple Majority vote with a quorum of two-thirds of the Total Number of
 Neither absentee nor proxy votes are allowed.
 House may choose any of the Outcomes for each member.
 \bsubsubsection{Outcomes}
-Members who receive a pass have the option to participate as an Active Member in the following year and remain on the upcoming roster if applicable.
+Members who pass Membership Evaluation have the option to participate as an Active Member in the following year and remain on the upcoming roster if applicable.
 \\* \\*
 If a member fails and has never passed a Membership Evaluation in the past, their membership will be revoked immediately.
 If the member has previously passed a Membership Evaluation they will move to Alumni Membership status at the end of the Standard Operating Session (\ref{Alumni Membership Selection}).

--- a/bylaws.tex
+++ b/bylaws.tex
@@ -269,7 +269,7 @@ A secret Simple Majority vote with a quorum of two-thirds of the Total Number of
 Neither absentee nor proxy votes are allowed.
 House may choose any of the Outcomes for each member.
 \bsubsubsection{Outcomes}
-Members who receive a pass have the option participate as an Active Member in the following the year and remain on the upcoming roster if applicable.
+Members who receive a pass have the option to participate as an Active Member in the following the year and remain on the upcoming roster if applicable.
 \\* \\*
 If a member fails and has never passed a Membership Evaluation in the past, their membership will be revoked immediately.
 If the member has previously passed a Membership Evaluation they will move to Alumni Membership status at the end of the Standard Operating Session (\ref{Alumni Membership Selection}).


### PR DESCRIPTION
Check one:
- [ ] Semantic Change: something about the meaning of the text is different
- [x] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

House was a little confused about some articles, an indefinite pronoun, consistency over proper names (which is actually a pretty deep rabbit hole that this PR does _not_ seek to address), and tense in the Evaluations Processes section. This PR addresses the non-semantic issues found therein.