### PR TITLE
updated typos

### DIFF
--- a/bylaws.tex
+++ b/bylaws.tex
@@ -4,7 +4,7 @@
 %  changed.
 % -This document must be ratified by the House (as per the Constitution), 
 %  then printed, signed, notarized, and placed in the House filing cabinet
-%  if changes are to be officialized.
+%  if changes are to be finalized.
 
 \documentclass{article}
 \providecommand{\RevisionInfo}{}
@@ -276,7 +276,7 @@ If the member has previously passed a Membership Evaluation they will move to Al
 In either case, the member forfeits their ability to be included on the following year’s roster.
 \\* \\*
 A member may be given a conditional to complete as a means of making up for missing requirements.
-A conditional may be proposed by any member present at the Evaluation and, if it is approved by the Evaluations Director, is then voted on by House.
+A conditional may be proposed by any member present at the Evaluation. If it is approved by the Evaluations Director, it is then voted on by House.
 Each conditional consists of a set of additional requirements a deadline for completing them.
 When the deadline expires, the conditional will be brought before the Executive Board who will assess its completeness.
 A conditional member who does not meet these additional requirements will have failed the evaluation.

--- a/bylaws.tex
+++ b/bylaws.tex
@@ -276,7 +276,7 @@ If the member has previously passed a Membership Evaluation they will move to Al
 In either case, the member forfeits their ability to be included on the following year’s roster.
 \\* \\*
 A member may be given a conditional to complete as a means of making up for missing requirements.
-A conditional may be proposed by any member present at the Evaluation. If it is approved by the Evaluations Director, it is then voted on by House.
+A conditional may be proposed by any member present at the Evaluation. If the conditional is approved by the Evaluations Director, it is then voted on by House.
 Each conditional consists of a set of additional requirements a deadline for completing them.
 When the deadline expires, the conditional will be brought before the Executive Board who will assess its completeness.
 A conditional member who does not meet these additional requirements will have failed the evaluation.


### PR DESCRIPTION
Check one:
- [ ] Semantic Change: something about the meaning of the text is different
- [ X] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Fixed typos in by-laws
line 7: officialized -> finalized
line 279: made run on sentence into 2 separate sentences to remove comma splice