### PR TITLE
Change to qualifications of OpComm Director

### DIFF
--- a/articles.tex
+++ b/articles.tex
@@ -297,7 +297,6 @@ They are generally very task oriented and are chaired by a House member.
 A directorship has some jurisdiction in its area of interest and often is responsible for the day-to-day decisions regarding its area of interest.
 Any large expenditures or large effect decisions must be brought before the entire House
 \asection{Members of the Executive Board}
-\asubsection{Chairman}
 \asubsection{Voting Members}
 \begin{itemize}
 	\item Evaluations Director
@@ -311,7 +310,8 @@ Any large expenditures or large effect decisions must be brought before the enti
 \asubsection{Non-Voting Members}
 \begin{itemize}
 	\item Ad Hoc Directors
-\asubsection{House Secretary}
+        \item House Secretary
+        \item Chairman
 \end{itemize}
 \asection{Closed Executive Board}
 Closed Executive Board Meetings are open only to the Chairman, Voting Members of the Executive Board, and those with the express permission of the Executive Board.
@@ -430,7 +430,7 @@ However, the Chairman and at least two-thirds of the Voting Members must be pres
 	\item Candidates must be Active Members during the term of office.
 	\item Candidates must reside on floor during the term of office.
 	\item Candidates must have at least one full semester of House membership as an Active Member.
-	\item Elected or selected candidates may not hold two simultaneous voting Executive Board positions, and must therefore resign their current position or decline a second position should they be elected or selected to a second voting position.
+	\item Elected or selected candidates may not hold a simultaneous voting Executive Board position, and must therefore resign their current position, or the position of Chairman, should they be elected.
 \end{enumerate}
 \asubsection{Qualifications to be the Social Director(s), Financial Director, Research and Development Director(s), House Improvements Director, House History Director}
 \begin{enumerate}

--- a/articles.tex
+++ b/articles.tex
@@ -442,7 +442,7 @@ However, the Chairman and at least two-thirds of the Voting Members must be pres
 \begin{enumerate}
 	\item Candidates must be a current Root Type Person \ref{Operations of the Operational Communications Directorship}
 	\item Candidates must be a current Active Member.
-	\item A Root Type Person cannot be the director if they currently hold any other Executive Board Position.
+	\item A Root Type Person cannot be the director if they currently hold any other voting Executive Board Position.
 \end{enumerate}
 
 \asubsection{Qualifications to be the House Secretary or an Ad Hoc Director}

--- a/articles.tex
+++ b/articles.tex
@@ -302,16 +302,16 @@ Any large expenditures or large effect decisions must be brought before the enti
 	\item Evaluations Director
 	\item Social Director(s)
 	\item Financial Director
-	\item Research and Development Director
+	\item Research and Development Director(s)
 	\item House Improvements Director
 	\item Operational Communications Director
 	\item House History Director
 \end{itemize}
 \asubsection{Non-Voting Members}
 \begin{itemize}
-	\item Ad Hoc Directors
+	\item Chairman 
         \item House Secretary
-        \item Chairman
+        \item Ad Hoc Director
 \end{itemize}
 \asection{Closed Executive Board}
 Closed Executive Board Meetings are open only to the Chairman, Voting Members of the Executive Board, and those with the express permission of the Executive Board.


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
I think that this is truly a non-semantic change, but I understand that we have to be cautious to the changing of the constitution so this will have to be amended the traditional way.  
This amendment changes the qualifications of the OpComm Director so that they are more consistent with the rest of the Executive Board's qualifications. 
