### PR TITLE
Failure to Get an Account After Packet is Failure to Complete Introductory Evaluations

### DIFF
--- a/bylaws.tex
+++ b/bylaws.tex
@@ -179,6 +179,7 @@ Each Introductory Process participant, after the first week, is given two (2) we
 	\item A list of seven (7) annual House social events
 	\item A list of seven (7) major House technical achievements
 \end{itemize}
+After the second week of the Introductory Packet, Introductory Members who have received less than 60\% (rounded up to the nearest whole person) of required signatures (excluding those of Resident members who have not passed a Membership Evaluation) will have their membership revoked.
 \bsubsection{Expectations of an Introductory Member}
 Before the end of the Process, an Introductory Member is expected to:
 \begin{itemize}
@@ -361,7 +362,7 @@ Root Type Persons have the authority to manage user accounts for House systems. 
 \renewcommand{\theenumi}{\alph{enumi}} % For this section, we want items to use letters
 \begin{enumerate}
 	\item Sign the Code of Conduct sheets pertaining to the responsible utilization of Computer Science House and Rochester Institute of Technology facilities.
-	\item Obtain greater than or equal to 60\% (rounded up to the nearest whole person) of required signatures (excluding those of Resident members who have not passed a Membership Evaluation) in the Introductory Packet or successfully complete Introductory Evaluations.
+	\item Obtain greater than or equal to 60\% (rounded up to the nearest whole person) of required signatures (excluding those of Resident members who have not passed a Membership Evaluation) in the Introductory Packet.
 \end{enumerate}
 
 \bsection{Code of Conduct}


### PR DESCRIPTION
Check one:
- [X] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
