### PR TITLE
Amendment Proposal to requirements to get account

### DIFF
--- a/bylaws.tex
+++ b/bylaws.tex
@@ -362,13 +362,11 @@ Root Type Persons have the authority to manage user accounts for House systems. 
 \begin{enumerate}
 	\item Sign the Code of Conduct sheets pertaining to the responsible utilization of Computer Science House and Rochester Institute of Technology facilities.
 	\item Obtain greater than or equal to 60\% (rounded up to the nearest whole person) of required signatures (excluding those of Resident members who have not passed a Membership Evaluation) in the Introductory Packet or successfully complete Introductory Evaluations.
-	\item An Introductory member who fails to meet the signature percentage requirement may be approved for an account by 50\% majority vote at a House Meeting.
-	This vote may be initiated by an Introductory member by notifying the Evaluations director of their intent after the completion of their packet.
-	The Evaluations director will conduct the vote during a subsequent House Meeting, as appropriate.
-	This may occur only once per Introductory Evaluation Process.
 \end{enumerate}
-
-\bsection{Code of Conduct}
+\item An Introductory member who fails to meet the signature percentage requirement may be approved for an account by 60\% majority vote at a House Meeting.
+ 	This vote may be initiated by an Introductory member by notifying the Evaluations director of their intent after the completion of their packet.
+ 	The Evaluations director will conduct the vote during a subsequent House Meeting, as appropriate.
+ 	This may occur only once per Introductory Evaluation Process.\bsection{Code of Conduct}
 The Code of Conduct located at \href{https://github.com/ComputerScienceHouse/CodeOfConduct} is the canonical Code of Conduct for Computer Science House accounts.
 \\* \\*
 Members are bound to the Code of Conduct revision that they sign when initially creating their account. Members may sign a more recent revision of the Code of Conduct to update their agreement.

--- a/bylaws.tex
+++ b/bylaws.tex
@@ -362,8 +362,12 @@ Root Type Persons have the authority to manage user accounts for House systems. 
 \begin{enumerate}
 	\item Sign the Code of Conduct sheets pertaining to the responsible utilization of Computer Science House and Rochester Institute of Technology facilities.
 	\item Obtain greater than or equal to 60\% (rounded up to the nearest whole person) of required signatures (excluding those of Resident members who have not passed a Membership Evaluation) in the Introductory Packet or successfully complete Introductory Evaluations.
+	\item An Introductory member who fails to meet the signature percentage requirement may be approved for an account by 50\% majority vote at a House Meeting.
+	This vote may be initiated by an Introductory member by notifying the Evaluations director of their intent after the completion of their packet.
+	The Evaluations director will conduct the vote during a subsequent House Meeting, as appropriate.
+	This may occur only once per Introductory Evaluation Process.
 \end{enumerate}
-\item Amendment Proposal: If an introductory member fails to meet the requirement of reaching 60\% to get an account after they have completed the two week packet period, the introsuctory member may have the Evals Director bring up a vote at one following house member to give the introductory member an account. This vote may happen once during the introductory member's 10 week evaluation process. The vote is a simple majority vote barring having enough member to meet Quorum
+
 \bsection{Code of Conduct}
 The Code of Conduct located at \href{https://github.com/ComputerScienceHouse/CodeOfConduct} is the canonical Code of Conduct for Computer Science House accounts.
 \\* \\*

--- a/bylaws.tex
+++ b/bylaws.tex
@@ -363,7 +363,7 @@ Root Type Persons have the authority to manage user accounts for House systems. 
 	\item Sign the Code of Conduct sheets pertaining to the responsible utilization of Computer Science House and Rochester Institute of Technology facilities.
 	\item Obtain greater than or equal to 60\% (rounded up to the nearest whole person) of required signatures (excluding those of Resident members who have not passed a Membership Evaluation) in the Introductory Packet or successfully complete Introductory Evaluations.
 \end{enumerate}
-
+\item Amendment Proposal: If an introductory member fails to meet the requirement of reaching 60\% to get an account after they have completed the two week packet period, the introsuctory member may have the Evals Director bring up a vote at one following house member to give the introductory member an account. This vote may happen once during the introductory member's 10 week evaluation process. The vote is a simple majority vote barring having enough member to meet Quorum
 \bsection{Code of Conduct}
 The Code of Conduct located at \href{https://github.com/ComputerScienceHouse/CodeOfConduct} is the canonical Code of Conduct for Computer Science House accounts.
 \\* \\*

--- a/bylaws.tex
+++ b/bylaws.tex
@@ -362,11 +362,13 @@ Root Type Persons have the authority to manage user accounts for House systems. 
 \begin{enumerate}
 	\item Sign the Code of Conduct sheets pertaining to the responsible utilization of Computer Science House and Rochester Institute of Technology facilities.
 	\item Obtain greater than or equal to 60\% (rounded up to the nearest whole person) of required signatures (excluding those of Resident members who have not passed a Membership Evaluation) in the Introductory Packet or successfully complete Introductory Evaluations.
-\end{enumerate}
-\item An Introductory member who fails to meet the signature percentage requirement may be approved for an account by 60\% majority vote at a House Meeting.
+	\item An Introductory member who fails to meet the signature percentage requirement may be approved for an account by 60\% majority vote at a House Meeting.
  	This vote may be initiated by an Introductory member by notifying the Evaluations director of their intent after the completion of their packet.
  	The Evaluations director will conduct the vote during a subsequent House Meeting, as appropriate.
  	This may occur only once per Introductory Evaluation Process.\bsection{Code of Conduct}
+\end{enumerate}
+
+\bsection{Code of Conduct}
 The Code of Conduct located at \href{https://github.com/ComputerScienceHouse/CodeOfConduct} is the canonical Code of Conduct for Computer Science House accounts.
 \\* \\*
 Members are bound to the Code of Conduct revision that they sign when initially creating their account. Members may sign a more recent revision of the Code of Conduct to update their agreement.


### PR DESCRIPTION
Check one:
- [X] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):


Amendment Proposal: If an introductory member fails to meet the requirement to get an account after they have completed the two week packet period, the introductory member may have the Evals Director bring up a vote at one preceding house member to give the introductory member an account. This vote may happen once during the introductory member's 10 week evaluation process. The vote is a simple majority barring meeting Quorum