### PR TITLE
Added Simple Majority specification to Evals votes

### DIFF
--- a/bylaws.tex
+++ b/bylaws.tex
@@ -212,7 +212,8 @@ On a member by member basis, this evaluation process determines if each Introduc
 \begin{enumerate}
 	\item The applicant submits an application to the Evaluations Director for review.
 	\item The applicant participates in an informal interview with exactly three current Active, Alumni, or Honorary Members.
-	\item The application materials are then reviewed at an Evaluations meeting and the members present vote on whether to accept the person as an introductory member.
+	\item The application materials are then reviewed at an Evaluations meeting. 
+	Then a simple majority vote, of attending members, is held on whether or not to accept the person as an introductory member.
 \end{enumerate}
 Note: Most membership privileges do not initiate until successful completion of the introductory process.
 This means that until the member has passed the introductory evaluation, the member does NOT have the right to vote on House issues and does NOT count towards quorum.


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Evaluations votes are counted as a simple majority presently, and therefore should be defined as such in the constituition. This simply ammends the simple majority requirement to evals votes wheras it was not presently defined.