### PR TITLE
Derivation of Directorship Budgets

### DIFF
--- a/bylaws.tex
+++ b/bylaws.tex
@@ -92,9 +92,29 @@ This process may be repeated indefinitely at the discretion of the Financial Dir
 \\*\\*
 All dues must be collected in full before the annual membership evaluation (\ref{Membership Evaluation}). After this date, dues collection is suspended until the start of the next academic year.
 \bsection{Derivation of Directorship Budgets}
-At the start of each operating session the Executive Board will create a proposed budget. Said budget will define the percentage of funds allotted for each director and what portion will be set aside for deposit into Computer Science House's accumulated funds. The total operational budget is to be defined by the Financial Director based on dues collection.
-\\*\\*
-In order for the budget to take effect it must pass a Two-Thirds Majority Executive Board vote with the Financial Director in favor.
+The total operational budget is to be defined by the Financial Director based on dues collection. The budget below outlines the percentage allotment for each director. 
+\begin{center}
+\begin{tabular}[c]{l c}
+Directorship Name & Percentage of Dues \\
+\hline
+\hline
+Operational Communications & 20\% \\
+\hline
+Evaluations \& Selections & 5\% \\
+\hline
+House History & 10\% \\
+\hline
+House Improvements & 20\% \\
+\hline
+Research and Development & 15\% \\
+\hline
+Social & 20\% \\
+\hline
+Addition to Accumulated Funds& 10\% \\
+\hline
+\end{tabular}
+\end{center}
+During the Operating Session, the Financial Director may propose an amended distribution that must be approved by a Simple Majority Executive Board vote.
 
 \bsection{Expenditure Approval}
 All House expenditures must be approved by both the Financial Director and the appropriate Director (from whose budget the funds will be drawn).

--- a/bylaws.tex
+++ b/bylaws.tex
@@ -91,32 +91,10 @@ If the Executive Board agrees with the Financial director, the member’s paymen
 This process may be repeated indefinitely at the discretion of the Financial Director and the Executive Board.
 \\*\\*
 All dues must be collected in full before the annual membership evaluation (\ref{Membership Evaluation}). After this date, dues collection is suspended until the start of the next academic year.
-\bsection{Breakdown of Dues for Directorship Budgets}
-\begin{center}
-\begin{tabular}[c]{l c}
-Directorship Name & Percentage of Dues \\
-\hline
-\hline
-Operational Communications & 20\% \\
-\hline
-Evaluations \& Selections & 5\% \\
-\hline
-House History & 10\% \\
-\hline
-House Improvements & 15\% \\
-\hline
-Research and Development & 20\% \\
-\hline
-Social & 20\% \\
-\hline
-Accumulated & 10\% \\
-\hline
-\end{tabular}
-\end{center}
-
-The suggested total operational budget is \$8064.
-This figure is based on yearly estimated on-floor member dues (\$160 x 56 members = \$8960) minus the 10\% reserved for Accumulated (Accum).
-Money allocated for Accum and off-floor member dues is deposited into the CSH Account and saved.
+\bsection{Derivation of Directorship Budgets}
+At the start of each operating session the Executive Board will create a proposed budget. Said budget will define the percentage of funds allotted for each director and what portion will be set aside for deposit into Computer Science House's accumulated funds. The total operational budget is to be defined by the Financial Director based on dues collection.
+\\*\\*
+In order for the budget to take effect it must pass a Two-Thirds Majority Executive Board vote with the Financial Director in favor.
 
 \bsection{Expenditure Approval}
 All House expenditures must be approved by both the Financial Director and the appropriate Director (from whose budget the funds will be drawn).


### PR DESCRIPTION
Check one:
- [X] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Per discussion in Financial a few weeks ago, I want to make it so that at the beginning of every year EBoard sits down and decides on a budget for the year based on historical percentages and forecasted purchases. Also changes the suggested budget to transfer 5% of the budget from R&D to House Improvements. 

