### PR TITLE
Revoke membership of advisors who no longer work for RIT

### DIFF
--- a/articles.tex
+++ b/articles.tex
@@ -268,7 +268,7 @@ Advisors are not subject to formal evaluations.
 An Advisor may resign by submitting in writing the reason for resignation to the Chairman.
 The resignation will be read at the following House Meeting and become effective at that time.
 \asubsection{Advisory Membership Term}
-Advisory Membership shall last until the member resigns.
+Advisory Membership shall last until the Advisor no longer meets the qualifications as defined in \ref{Advisory Membership Qualifications} or until the Advisor resigns.
 
 \asection{Leave of Absence}
 A leave of absence offers the option for members to take extended time away from their responsibilities to House for any number of personal issues including, but not limited to, physical illness, mental illness, or care giving for a sick family member. Computer Science House recognizes the need for its members to take care of their personal well-being and will support them through the process of requesting a leave of absence as well as acclimating back to the culture of House upon their return. Upon approval of a leave of absence request, the Evaluations Director is notified and the member's leave is applied immediately. A member is also allowed to be physically present and also be on a leave of absence. 


### PR DESCRIPTION
Check one:
- [X] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

Currently, once an Advisor gains Advisory Membership, they keep it indefinitely, unless they explicitly resign. This amendment modifies the Advisory Membership Term section of the Articles to define that if their employment by RIT is terminated _or_ they resign, their membership should be revoked.
