### PR TITLE
Semantic change discussion clarification

### DIFF
--- a/articles.tex
+++ b/articles.tex
@@ -98,7 +98,8 @@ Alternatively, the change may be presented to the House for discussion followed 
 A quorum of fifty percent of the Total Number of Possible Votes is required for passage.
 
 \asubsection{Semantic Changes}
-Any semantic change to the Constitution requires the change to be proposed in writing for discussion at a House Meeting.
+Any semantic change to the Constitution requires the change to be proposed in writing at a House Meeting.  
+Discussion of the wording and the implications of the change should be held immediately following the proposal.
 Any modifications made due to the discussion are added to the written proposal and the modified proposal is posted in the House during the week.
 The final proposal is presented the following week and ballots are distributed for a ballot House vote as described in \ref{Balloted Vote}.
 The ballots are collected for a minimum of a forty-eight hour period.


### PR DESCRIPTION
Check one:
- [X] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):


Exactly when house wide discussions of semantic changes should be held is currently vague and unclear.  Currently, we have discussion on amendments one week after their proposal.  The current wording could easily be interpreted as meaning otherwise.  This change would require proposed amendments to be discussed immediately after being proposed, rather than one week later.  This change would prevent members from voting no on an amendment simply because they don't like the wording of the amendment as they would have been able to discuss their issues involving wording and phrasing one week prior to voting.  
As is, the constitution says that after an amendment's discussion, the amendment creator will have one week to edit and re work the amendment.  Currently, there is absolutely no time for a change to be made to amendment following it's house wide discussion.