### PR TITLE
Leave of Absence Grammar

### DIFF
--- a/articles.tex
+++ b/articles.tex
@@ -275,7 +275,7 @@ Advisory Membership shall last until the member resigns.
 
 \asection{Leave of Absence}
 A leave of absence offers the option for members to take extended time away from their responsibilities to House for any number of personal issues including, but not limited to, physical illness, mental illness, or care giving for a sick family member.
-Computer Science House recognizes the need for its members to take care of their personal well-being and will support them through the process of requesting a leave of absence as well as acclimating back to the culture of House upon their return.
+Computer Science House recognizes the need for its members to take care of their personal well-being and will support them through the process of requesting a leave of absence as well as reacclimate back to the culture of House upon their return.
 Upon approval of a leave of absence request, the Evaluations Director is notified and the member's leave is applied immediately.
 A member is also allowed to be physically present and also be on a leave of absence.
 \asubsection{Leave of Absence Request}

--- a/articles.tex
+++ b/articles.tex
@@ -275,7 +275,8 @@ Advisory Membership shall last until the member resigns.
 
 \asection{Leave of Absence}
 A leave of absence offers the option for members to take extended time away from their responsibilities to House for any number of personal issues including, but not limited to, physical illness, mental illness, or care giving for a sick family member.
-Computer Science House recognizes the need for its members to take care of their personal well-being and will support them through the process of requesting a leave of absence as well as reacclimate back to the culture of House upon their return.
+Computer Science House recognizes the need for its members to take care of their personal well-being and will support them through the process of requesting a leave of absence. 
+House will also help to reacclimate any returning member back to the culture of House upon their return.
 Upon approval of a leave of absence request, the Evaluations Director is notified and the member's leave is applied immediately.
 A member is also allowed to be physically present and also be on a leave of absence.
 \asubsection{Leave of Absence Request}


### PR DESCRIPTION
Check one:
- [ ] Semantic Change: something about the meaning of the text is different
- [x] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
I noticed that the Section regarding Leave's of Absence was a little long winded. I decided to break it up slightly and fix the wording of "acclimating" to "reacclimate". 
Reacclimate: To acclimate again; to reaccustom.
Acclimating: To become accustomed to a new climate or environment, the act of