### PR TITLE
swapped an apostophe for one that actually compiles

### DIFF
--- a/articles.tex
+++ b/articles.tex
@@ -527,7 +527,7 @@ The resignation will be read at the following House Meeting and become effective
 The office will become vacant and the selection process for a new member as described in section \ref{Appointment of an Interim Director} will begin at that time.
 
 \asection{Appointment of an Interim Director}
-The duties and responsibilities of a vacated office are assumed by the Chairman or by an Active member that is appointed at the Chairman’s discretion until the new member takes office.
+The duties and responsibilities of a vacated office are assumed by the Chairman or by an Active member that is appointed at the Chairman's discretion until the new member takes office.
 The vote of a vacated Executive Board position shall be cast as an abstention in all Executive Board matters where this vote is required to be cast.
 
 \asection{Impeachment}


### PR DESCRIPTION
Check one:
- [ ] Semantic Change: something about the meaning of the text is different
- [x] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
The apostrophe in the changed line in the current version of the constitution doesn't appear in a compiled version. I do not know why. I changed it to a regular single-quote character and it appears to compile as intended. 

Rip spelling mistake in commit
