### PR TITLE
Silly Markdown issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 The master branch's HEAD is the current legal constitution of CSH.
 
 Compiled version of both documents can be found below:
-####[Articles](https://constitution.csh.rit.edu/articles.pdf)
-####[By-Laws](https://constitution.csh.rit.edu/bylaws.pdf)
+#### [Articles](https://constitution.csh.rit.edu/articles.pdf)
+#### [By-Laws](https://constitution.csh.rit.edu/bylaws.pdf)
 
 ## Modifying the Constitution
 **Do not** make changes to master without their passing the proper house voting


### PR DESCRIPTION
Articles and Bylaws links were not being rendered correctly

Check one:
- [ ] Semantic Change: something about the meaning of the text is different
- [x] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

