### PR TITLE
Corrected Non-Voting Members section and removed trailing whitespaces

### DIFF
--- a/articles.tex
+++ b/articles.tex
@@ -1,8 +1,8 @@
 % BEFORE CHANGES ARE MADE TO THIS DOCUMENT:
-% -References will be automatically updated if any part is added, deleted, etc. 
-%  However, if a sub part is moved to a different part, its references must be 
+% -References will be automatically updated if any part is added, deleted, etc.
+%  However, if a sub part is moved to a different part, its references must be
 %  changed.
-% -This document must be ratified by the House (as per the Constitution), 
+% -This document must be ratified by the House (as per the Constitution),
 %  then printed, signed, notarized, and placed in the House filing cabinet
 %  if changes are to be officialized.
 
@@ -12,7 +12,7 @@
 \usepackage{xr-hyper}
 \usepackage{hyperref}
 
-% This package is useful for debugging label problems 
+% This package is useful for debugging label problems
 % Comment out in final revision
 %\usepackage{showkeys}
 
@@ -275,7 +275,7 @@ Advisory Membership shall last until the member resigns.
 
 \asection{Leave of Absence}
 A leave of absence offers the option for members to take extended time away from their responsibilities to House for any number of personal issues including, but not limited to, physical illness, mental illness, or care giving for a sick family member.
-Computer Science House recognizes the need for its members to take care of their personal well-being and will support them through the process of requesting a leave of absence. 
+Computer Science House recognizes the need for its members to take care of their personal well-being and will support them through the process of requesting a leave of absence.
 House will also help to reacclimate any returning member back to the culture of House upon their return.
 Upon approval of a leave of absence request, the Evaluations Director is notified and the member's leave is applied immediately.
 A member is also allowed to be physically present and also be on a leave of absence.
@@ -322,9 +322,9 @@ Any large expenditures or large effect decisions must be brought before the enti
 \end{itemize}
 \asubsection{Non-Voting Members}
 \begin{itemize}
-	\item Chairman 
+	\item Chairman
 	\item House Secretary
-	\item Ad Hoc Director
+	\item Ad Hoc Director (s)
 \end{itemize}
 \asection{Closed Executive Board}
 Closed Executive Board Meetings are open only to the Chairman, Voting Members of the Executive Board, and those with the express permission of the Executive Board.
@@ -602,28 +602,28 @@ The Vote Counters then tally the results.
 
 Voters rank the options by placing a '1' by their first choice, a '2' by their second choice, and so on, until they no longer wish to express any further preferences or run out of options.
 
-\asubsubsection{Voting Period} 
+\asubsubsection{Voting Period}
 For constitutional modification, candidate selection, and officer removal votes, the voting period must be at least forty-eight (48) hours in length.
 For any other type of vote, the voting period must be at least twenty-four (24) hours.
 The minimum length of the voting period may be explicitly lengthened, but never shortened, in the text describing the actual vote.
 \asubsection{Balloted Vote}
-\asubsubsection{Method of Vote} 
+\asubsubsection{Method of Vote}
 Votes are cast on paper ballots, which provide a means to indicate every possible option in the vote.
 A ballot is then distributed to each House member eligible to cast a vote and collected in the designated ballot box for a pre-specified length of time.
 At the end of the voting period, the person chairing the vote collects the ballots, closing the voting period.
 The Vote Counters then tally the results.
-\asubsubsection{Voting Period} 
+\asubsubsection{Voting Period}
 For constitutional modification, candidate selection, and officer removal votes, the voting period must be at least forty-eight (48) hours in length.
 For any other type of vote, the voting period must be at least twenty-four (24) hours.
 The minimum length of the voting period may be explicitly lengthened, but never shortened, in the text describing the actual vote.
 \asubsection{Immediate Vote}
-\asubsubsection{Method of Vote} 
+\asubsubsection{Method of Vote}
 The person chairing the vote will state all possible ways to vote, then call out each possibility one at a time.
 The chairing member will count the number of members casting their immediate vote for that possibility.
-\asubsubsection{Voting Period} 
+\asubsubsection{Voting Period}
 An immediate vote lasts as long as it takes for all votes to be tallied.
 \asubsection{Secret Immediate Vote}
-\asubsubsection{Method of Vote} 
+\asubsubsection{Method of Vote}
 The person chairing the vote will state all possible ways to vote, then call out each possibility one at a time.
 Votes are kept anonymous.
 The chairing member and Vote Counters will count the number of members casting their immediate vote for that possibility.

--- a/bylaws.tex
+++ b/bylaws.tex
@@ -1,8 +1,8 @@
 % BEFORE CHANGES ARE MADE TO THIS DOCUMENT:
-% -References will be automatically updated if any part is added, deleted, etc. 
-%  However, if a sub part is moved to a different part, its references must be 
+% -References will be automatically updated if any part is added, deleted, etc.
+%  However, if a sub part is moved to a different part, its references must be
 %  changed.
-% -This document must be ratified by the House (as per the Constitution), 
+% -This document must be ratified by the House (as per the Constitution),
 %  then printed, signed, notarized, and placed in the House filing cabinet
 %  if changes are to be finalized.
 
@@ -36,7 +36,7 @@
 
 % Use \article for articles and \asection for sections of articles.
 % Automatically provide labels with the same article or section title.
-\newcommand{\bylaw}[1]{\section{#1} \label{#1}} 
+\newcommand{\bylaw}[1]{\section{#1} \label{#1}}
 \newcommand{\bsection}[1]{\subsection{#1} \label{#1}}
 \newcommand{\bsubsection}[1]{\subsubsection{#1} \label{#1}}
 \renewcommand{\thesection}{By-Law \Roman{section}}
@@ -154,11 +154,11 @@ The Introductory Executive Board consists of three members:
 	\item A Treasurer, who manages the finances for the project.
 \end{itemize}
 Introductory Members also elect a Secretary to take notes, and any number of additional non-voting leaders may be elected to take on project-specific tasks.
-\bsubsubsection{The Project} 
+\bsubsubsection{The Project}
 The Project is an annual fundraising event that takes place in the first semester of the Introductory Process.
 All of the proceeds go to a charity chosen in advance by the participants.
 The Executive Board is encouraged to discuss the Project and following an open ballot Simple Majority Vote, may choose to intervene in the Introductory Project if the Project does not appear to fulfill requirements.
-\bsubsubsection{Introductory Project Advisors} 
+\bsubsubsection{Introductory Project Advisors}
 The Evaluations Director may choose between one (1) and three (3) House members to be Introductory Project Advisors.
 The advisors assist in organizing the participants at the beginning of the Introductory Project and thereafter act as a resource to keep the Project running smoothly.
 \bsubsection{The Introductory Packet}
@@ -166,7 +166,7 @@ Each Introductory Process participant, after the first week, is given two (2) we
 \begin{itemize}
 	\item A signature from all Active/Introductory Resident members, each Executive Board member, and fifteen (15) of any combination of the following:
 	\begin{itemize}
-		\item Non-Resident members who have passed a Membership Evaluation 
+		\item Non-Resident members who have passed a Membership Evaluation
 		\item Alumni members (not including Non-Resident Executive Board members)
 		\item Honorary members
 		\item Advisory members
@@ -195,12 +195,12 @@ Before the end of the Process, an Introductory Member is expected to:
 \bsubsection{Introductory Evaluation}
 The Introductory Evaluation is the process by which House chooses which Introductory Members to extend an offer of full Resident or Non-Resident Membership.
 Occurs once per academic year as part of the Introductory Process.
-\bsubsubsection{Voting} 
+\bsubsubsection{Voting}
 On a member by member basis, this evaluation process determines if each Introductory member has successfully completed the Introductory Process requirements \ref{Expectations of an Introductory Member}.
 A Simple Majority vote with a quorum of two-thirds of the Total Number of Possible Votes is required for the evaluation to be valid.
 Neither absentee nor proxy votes are allowed.
 House may choose any of the Outcomes for each member.
-\bsubsubsection{Outcomes} 
+\bsubsubsection{Outcomes}
 \renewcommand{\theenumi}{\alph{enumi}} % For this section, we want items to use letters
 \begin{enumerate}
 	\item Introductory Members may be offered Active Membership (\ref{Active Membership}) provided they meet the requirements described in \ref{Expectations of an Introductory Member}, at the discretion of House.
@@ -218,7 +218,7 @@ House may choose any of the Outcomes for each member.
 \begin{enumerate}
 	\item The applicant submits an application to the Evaluations Director for review.
 	\item The applicant participates in an informal interview with exactly three current Active, Alumni, or Honorary Members.
-	\item The application materials are then reviewed at an Evaluations meeting. 
+	\item The application materials are then reviewed at an Evaluations meeting.
 	Then a simple majority vote, of attending members, is held on whether or not to accept the person as an introductory member.
 \end{enumerate}
 Note: Most membership privileges do not initiate until successful completion of the introductory process.
@@ -274,7 +274,7 @@ All members may notify the evaluations director before the end of the academic y
 \bsubsection{Membership Evaluation}
 The Membership Evaluation process occurs once per academic year.
 It is performed as part of the Evaluation Process that takes place during the spring semester to comply with RIT Housing deadlines.
-\bsubsubsection{Voting} 
+\bsubsubsection{Voting}
 A quorum of members, on a member by member basis, ensures that each Active Member has met the minimum requirements in order to continue as an Active Member in the following year.
 All Active Members will be held to the requirements and evaluated unless they have received an exemption from the Executive Board prior to the event.
 These requirements are detailed in Article V under expectations for each category of membership.


### PR DESCRIPTION
Check one:
- [ ] Semantic Change: something about the meaning of the text is different
- [X] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Changed Non-Voting Members section of the Executive Board to reflect the fact that there can be more than one ad hoc director at a time.
Also removed ALL trailing whitespaces from .tex files.

