### PR TITLE
Corrected singular noun used in non voting eboard member section

### DIFF
--- a/articles.tex
+++ b/articles.tex
@@ -324,7 +324,7 @@ Any large expenditures or large effect decisions must be brought before the enti
 \begin{itemize}
 	\item Chairman 
 	\item House Secretary
-	\item Ad Hoc Director
+	\item Ad Hoc Director(s)
 \end{itemize}
 \asection{Closed Executive Board}
 Closed Executive Board Meetings are open only to the Chairman, Voting Members of the Executive Board, and those with the express permission of the Executive Board.


### PR DESCRIPTION
Check one:
- [ ] Semantic Change: something about the meaning of the text is different
- [X] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Fixed non-voting member list under the executive board section to reflect the fact that more than one ad hoc director can exist at once.
