### PR TITLE
Remove RHA, update formal name for ResLife

### DIFF
--- a/articles.tex
+++ b/articles.tex
@@ -67,7 +67,7 @@
 The name of this Special Interest House shall be Computer Science House.
 
 \asection{Derivation of Authority}
-The Computer Science House shall recognize that it receives its right to function as a Special Interest House from the Department of Residence Life in conjunction with the Residence Halls Association.
+The Computer Science House shall recognize that it receives its right to function as a Special Interest House from the Center for Residence Life.
 
 \asection{House Objectives}
 The objectives of Computer Science House are:


### PR DESCRIPTION
Check one:
- [X] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

The Residence Halls Association is no more, so removed the reference to it. Also updated the formal name of ResLife to make is less ambiguous and change "Department" to "Center" to match their website: http://www.rit.edu/studentaffairs/reslife/