### PR TITLE
Addition of rules for the handling of bullying, abuse, and judicial proceedings

### DIFF
--- a/articles.tex
+++ b/articles.tex
@@ -668,13 +668,18 @@ In the event of a tie in an Executive Board vote, the Chairman may cast the tie-
 % ARTICLE VI - JUDICIAL
 \article{Judicial}
 The Executive Board may approve (by simple majority) a request (from a member) for a Judicial proceeding when an official clarification of the Constitution or By-Laws is required, there is a conflict among House Members, or a House interest needs resolution.
+If a member comes forward with allegations that abusive speech, bullying, or threats are occurring to them from another member, a Judicial proceeding is immediately started, without the need for Executive Board approval.
+In the case of a member coming forward with an accusation of assault or more serious actions, the matter and all information known about it is immediately forwarded to The Department of Residence Life and/or the relevant department at RIT, bypassing any Executive Board decisions.
 \asection{Formation of a Judicial Board}
 A Judicial Board is made up of the Chairman, the Evaluations director, and an additional voting member of the Executive Board chosen by a majority vote among the Executive Board.
-If either the Chairman or Evaluations Director are deemed biased or unfit for a position on the Judicial Board, they will be replaced by another voting member of the Executive Board by means of a simple majority vote amongst the remaining Executive Board members.
+If either of the two non-Chairman member of the Executive Board are deemed biased, unfit for a position on the Judicial Board, or are involved in the Judicial as an accuser or accused, the Judicial Board will instead be composed of 2 non-Executive Board members randomly chosen from active on-floor members, and the Chairman.
+If the Chairman is deemed biased, unfit for a position on the Judicial Board, or involved in the Judicial as an accuser or accused, the Judicial Board will be composed of 3 non-Executive Board members randomly chosen from active on-floor members.
 \asection{Judicial Investigation}
 The Judicial Board will be responsible for making all necessary inquiries into the matter of the request brought to the Judicial Board.
+For Judicial proceedings initiated from a claim of abusive speech, bullying, or threats, the accuser is able to directly introduce evidence (including witnesses) to the meeting the Judicial decision occurs at. It is also required that all witnesses be interviewed by the board during the decision making meeting.
 \asection{Judicial Ruling}
 The Judicial Board may present an official ruling following the Judicial Investigation.
 This ruling may be appealed in the same manner as an Executive Board decision \ref{Appeals}.
+From a Judicial proceedings initiated from a claim of abusive speech, bullying, or threats, if the claims are found to be true and are severe enough that it can be classified as extreme (the member claims they were encouraged to commit suicide, feel physically unsafe, are unable to be in their room without fear), or the offender has refused to heed previous warnings concerning actions towards the accuser, them the offender's membership is immediately removed, and the incident, along with all known pertinent information, is elevated to RIT and/or The Department of Residence Life’s attention.
 
 \end{document}


### PR DESCRIPTION
Check one:
- [X] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Improve handling of abuse and bullying claims, how the Judicial occurs for them, and the outcome of the judicial. This is done to prevent the silencing of abuse, and sidelining of bullying issues. Also serves to ensure impartiality and prevent the dropping of cases due to abusers in positions of power.

Change handling of cases where a Judicial occurs involving an e-board member. Needed because it is unlikely e-board can remain impartial when judging another e-board member.

