### PR TITLE
Fix wording inconsistency when describing major projects

### DIFF
--- a/bylaws.tex
+++ b/bylaws.tex
@@ -304,7 +304,7 @@ If the member is still unsatisfied after being heard by the Executive Board, the
 Each member is required to pay House dues as stated in \ref{Collection of House Dues}, attend all House Meetings, and attend at least twenty-five (25) of the permanent director meetings.
 Members are also required to actively participate in a majority of House activities.
 \\* \\*
-The member must participate significantly in at least one major House project during the academic year.
+The member must participate significantly in at least one major project during the academic year.
 The member is required to submit a description for this major project to the Executive Board for approval.
 As an option to this requirement, the member may instead assist on a large number of House activities and projects.
 However, it is to be understood in advance by the member that this option requires a great deal of participation throughout the year.


### PR DESCRIPTION
Check one:
- [ ] Semantic Change: something about the meaning of the text is different
- [x] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
The Expectations of House Members section refers to major projects two different ways, one of which is "major House project". That wording doesn't seam to appear in any other part of the constitution and isn't even consistent with the line following. The major project is well defined in the constitution and as such this is a change for consistency's sake, and doesn't change the meaning of the term.
