### PR TITLE
bylaws: Update standard operating session length

### DIFF
--- a/bylaws.tex
+++ b/bylaws.tex
@@ -74,7 +74,7 @@ By-Laws provide additional depth and definition to the processes and operations 
 % BY-LAW II - GENERAL OPERATIONS OF THE HOUSE
 \bylaw{General Operations of the House}
 \bsection{Standard Operating Session}
-The Standard Operating Session for Computer Science House is during the thirty weeks of Fall and Spring semesters.
+The Standard Operating Session for Computer Science House is during the twenty-eight weeks of Fall and Spring semesters.
 The Summer Sessions, Intersessions, Institute breaks, and all end of Semester Exam Weeks are considered non-standard operating sessions.
 Unless explicitly stated otherwise, the requirements and expectations defined in the constitution are for the Standard Operating Session.
 


### PR DESCRIPTION
Check one:
- [X] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
RIT now uses a 14-week semester schedule. Update the length of the standard operating session accordingly.
