### PR TITLE
Clarify membership meeting requirements

### DIFF
--- a/bylaws.tex
+++ b/bylaws.tex
@@ -192,7 +192,7 @@ Before the end of the Process, an Introductory Member is expected to:
 \item Attend all House meetings during the process
 \item Complete the Introductory Packet
 \item Be an active participant in the Introductory Project
-\item Attend at least one House directorship meeting for each week of the process
+\item Attend at least one House directorship meeting for each week of the process (including permanent and Ad-Hoc directorship meetings)
 \item Attend at least one House social event during the process
 \item Attend at least two seminars relating to computing or electronics
 \item Sign a copy of the Membership Agreement describing a House Member’s responsibilities and expectations
@@ -307,7 +307,7 @@ If a member disagrees with the outcome of any evaluation, (e.g. is not asked to 
 If the member is still unsatisfied after being heard by the Executive Board, the appeal may be brought to the attention of the ResLife Advisor.
 
 \bsection{Expectations of House Members}
-Each member is required to pay House dues as stated in \ref{Collection of House Dues}, attend all House Meetings, and attend at least twenty-five (25) of the permanent director meetings.
+Each member is required to pay House dues as stated in \ref{Collection of House Dues}, attend all House Meetings, and attend at least twenty-five (25) of the House directorship meetings (including permanent and Ad-Hoc directorship meetings).
 Members are also required to actively participate in a majority of House activities.
 \\* \\*
 The member must participate significantly in at least one major project during the academic year.


### PR DESCRIPTION
Allow ad-hoc directorship meetings to count towards both
the introductory evaluations process as well as the spring
evaluations process

Wording can change need be

Check one:
- [X] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

