### PR TITLE
Scale directorship meeting requirement by semester

### DIFF
--- a/bylaws.tex
+++ b/bylaws.tex
@@ -307,7 +307,7 @@ If a member disagrees with the outcome of any evaluation, (e.g. is not asked to 
 If the member is still unsatisfied after being heard by the Executive Board, the appeal may be brought to the attention of the ResLife Advisor.
 
 \bsection{Expectations of House Members}
-Each member is required to pay House dues as stated in \ref{Collection of House Dues}, attend all House Meetings, and attend at least twenty-five (25) of the House directorship meetings (including permanent and Ad-Hoc directorship meetings).
+Each member is required to pay House dues as stated in \ref{Collection of House Dues}, attend all House Meetings, and attend at least fifteen (15) of the House directorship meetings (including permanent and Ad-Hoc directorship meetings) for each Academic Semester in which they are an Active Member.
 \\* \\*
 The member must participate significantly in at least one major project during the academic year.
 The member is required to submit a description for this major project to the Executive Board for approval.


### PR DESCRIPTION
Check one:
- [X] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Scale the permanent directorship meeting requirement based on how many semesters a member is active for. This moves the requirement in line (more or less) with the requirement for introductory members (one per week).

Things to note:
* I made the requirement fifteen per semester rather than one per week for a few reasons. The primary reason is that scaling it per week seems too fine-grained to me, and requires considerable extra bookkeeping. Scaling by week also makes the requirements per semester 14, which isn't quite as round a number as I'd like. It also made the wording slightly more cumbersome.
* I'm not convinced the wording of my change is ideal, so I'd welcome feedback on how to improve that. In particular, I want to make sure it doesn't read as requiring meeting attendance to actually be distributed to 15 per semester - just a total of 30 for the whole year, if you're active both semesters.