### PR TITLE
Fixed estimate to account for Fish

### DIFF
--- a/bylaws.tex
+++ b/bylaws.tex
@@ -122,7 +122,7 @@ Accumulated & 10\% \\
 \end{center}
 
 The suggested total operational budget is \$8064.
-This figure is based on yearly estimated on-floor member dues (\$160 x 56 members = \$8960) minus the 10\% reserved for Accumulated (Accum).
+This figure is based on yearly estimated on-floor member dues (\$160 x 72 members = \$11520) minus the 10\% reserved for Accumulated (Accum).
 Money allocated for Accum and off-floor member dues is deposited into the CSH Account and saved.
 
 \bsection{Expenditure Approval}


### PR DESCRIPTION
The max number of on-floor members didn't account for Fish.

Check one:
- [ ] Semantic Change: something about the meaning of the text is different
- [x] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

