### PR TITLE
Moving Housing Point Allocation to Spring Evals

### DIFF
--- a/bylaws.tex
+++ b/bylaws.tex
@@ -275,8 +275,6 @@ All Executive Board members are expected to attend the Semi-Annual Evaluations M
 \\* \\*
 At the beginning of any Evaluation Process listed herein, the Evaluations Director must read the sections of the Computer Science House Constitution and By-Laws used during the respective Evaluation Process.
 It is incumbent upon each House member to provide the Evaluation Director with whatever information they feel is necessary to ensure an accurate evaluation.
-\bsubsection{Housing Points}
-All members may notify the evaluations director before the end of the academic year that they would like to receive two housing points for use in the next academic year.
 \bsubsection{Membership Evaluation}
 The Membership Evaluation process occurs once per academic year.
 It is performed as part of the Evaluation Process that takes place during the spring semester to comply with RIT Housing deadlines.
@@ -290,6 +288,7 @@ Neither absentee nor proxy votes are allowed.
 House may choose any of the Outcomes for each member.
 \bsubsubsection{Outcomes}
 Members who pass Membership Evaluation have the option to participate as an Active Member in the following year and remain on the upcoming roster if applicable.
+All members who pass Membership Evaluation will recieve two housing points for use in the following academic years.
 \\* \\*
 If a member fails and has never passed a Membership Evaluation in the past, their membership will be revoked immediately.
 If the member has previously passed a Membership Evaluation they will move to Alumni Membership status at the end of the Standard Operating Session (\ref{Alumni Membership Selection}).
@@ -330,7 +329,7 @@ They still have access to all other privileges associated with their membership,
 \bsection{Housing Priority System}
 The Housing Priority System is a means for determining the priority a House member has in a Housing issue such as Single Room Assignment or the Assignment of Available Housing.
 The member with top priority is the member with on-floor status and the most Housing Priority Points.
-Housing points are accumulated during the Housing Evaluation described in \ref{Housing Evaluation}.
+Housing points are accumulated during the Membership Evaluation described in \ref{Membership Evaluation}.
 \\* \\*
 In the event of a tie, the members will be approached simultaneously and if they are unable to decide fairly between themselves, the assignment of priority will be made by random selection of the tied members.
 \bsubsection{Single Room Assignments}


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Removing the need for a Housing Points Form and moving the allocation of Housing Points to Spring evals.
1. To encourage upperclassmen to try on Spring Evals
2. To remove a need to just distribute points based on the filling out of a from