### PR TITLE
Remove Pedantic Wording

### DIFF
--- a/articles.tex
+++ b/articles.tex
@@ -684,7 +684,6 @@ This ruling may be appealed in the same manner as an Executive Board decision \r
 \article{Temporary Amendments}
 In the case that an amendment should be temporary, the amendment's changes should be listed here. 
 Each of these amendments is given a designated period of time, and will cease to exist immediately following the end of the period.
-If at any point interpretation of the changes needs to be made, the Executive Board will use the process defined in \ref{Judicial} to come to an agreement on how to proceed. 
 Occasionally, Temporary Amendments may become permanent through a referendum, which is described in detail as part of each Temporary Amendment. 
 \asection{Changes to Evaluations}
 During the 2018-2019 period the following will supercede the text otherwise found in this document.


### PR DESCRIPTION
Judicial Process automatically covers the Temporary Amendment section.

Check one:
- [ ] Semantic Change: something about the meaning of the text is different
- [X] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Judicials were mentioned as the only source to make changes and interpretation to the temporary amendments section. This is pretty stupid. 