### PR TITLE
Update packet signature requirements

### DIFF
--- a/bylaws.tex
+++ b/bylaws.tex
@@ -170,9 +170,8 @@ The advisors assist in organizing the participants at the beginning of the Intro
 \bsubsection{The Introductory Packet}
 Each Introductory Process participant, after the first week, is given two (2) weeks to return a document that should contain the following:
 \begin{itemize}
-	\item A signature from all Active/Introductory Resident members, each Executive Board member, and fifteen (15) of any combination of the following:
+	\item A signature from all Active members, all Introductory Resident members, each Executive Board member, and ten (10) of any combination of the following:
 	\begin{itemize}
-		\item Non-Resident members who have passed a Membership Evaluation
 		\item Alumni members (not including Non-Resident Executive Board members)
 		\item Honorary members
 		\item Advisory members

--- a/bylaws.tex
+++ b/bylaws.tex
@@ -170,9 +170,9 @@ The advisors assist in organizing the participants at the beginning of the Intro
 \bsubsection{The Introductory Packet}
 Each Introductory Process participant, after the first week, is given two (2) weeks to return a document that should contain the following:
 \begin{itemize}
-	\item A signature from all Active members, all Introductory Resident members, each Executive Board member, and ten (10) of any combination of the following:
+	\item A signature from all Active members, all Introductory Resident members, and ten (10) of any combination of the following:
 	\begin{itemize}
-		\item Alumni members (not including Non-Resident Executive Board members)
+		\item Alumni members
 		\item Honorary members
 		\item Advisory members
 	\end{itemize}


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

- Requires signature of **all** active members (both on- and off-floor)
- Lowers requirement of alumni (non-active members), advisors, and honorary members to 10, since off-floors now count under the active member category