### PR TITLE
Remove 'essay' requirement from intro packet

### DIFF
--- a/bylaws.tex
+++ b/bylaws.tex
@@ -177,14 +177,6 @@ Each Introductory Process participant, after the first week, is given two (2) we
 		\item Honorary members
 		\item Advisory members
 	\end{itemize}
-	\item A description of each Executive Board position, including:
-	\begin{itemize}
-		\item The responsibilities of the position
-		\item The name(s) of the position’s member(s)
-		\item The position’s weekly meeting time
-	\end{itemize}
-	\item A list of seven (7) annual House social events
-	\item A list of seven (7) major House technical achievements
 \end{itemize}
 \bsubsection{Expectations of an Introductory Member}
 Before the end of the Process, an Introductory Member is expected to:


### PR DESCRIPTION
Check one:
- [X] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Removes the "essay" requirements from the intro packet. It's antiquated with no real reason to include it that I've heard other than to have a very low hurdle for freshmen. This year we had someone hit 100% on packet but "fail" packet because they didn't submit the essay. IMO, if house decides someone is good enough to get 100, that's more than enough proof that them looking at the Calendar and pubsite doesn't change anything.