### PR TITLE
Removes the PR Directorship

### DIFF
--- a/articles.tex
+++ b/articles.tex
@@ -697,17 +697,6 @@ During the described period, the percentage of required signatures in the Introd
 \asubsubsection{Changes to Packet Times}
 Introductory Members will recieve \ref{The Introductory Packet} following the House Meeting or Evaluations Directorship meeting of the second week of each semester. 
 Each Introductory Member will submit their packet at the end of week 3. 
-\asubsubsection{PR Director} 
-The Public Relations Director will be added to \ref{Voting Members}. 
-The Public Relations Director will be given half of Accumulated's budget (5\% of the total Directorships Budget.) 
-The Public Relations Director will be given the following responsibilities during the described period. 
-\begin{enumerate}
-	\item To preside over Public Relations Directorship Meetings.
-	\item To exercise general supervision over Public Relations operations.
-	\item To communicate clearly with Rochester Institute of Technology's extended community.
-	\item To collaborate with the Social and Evaluations Directors to ensure that \ref{The Introductory Process} is directed correctly.
-	\item To advertise any events run by Evaluations Director and/or Social Director(s) that are intended to be attended by RIT Students whom are not Computer Science House Members.  
-\end{enumerate}
 \asubsubsection{Evaluation Period}
 During the described period, the \ref{The Introductory Process} will begin during the first week of each semester.
 The Executive Board may hold a Simple Majority vote to extend the Introductory Process or the Introductory Packet during the described period.


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Removes the PR Directorship (7.A.1.D) from the Temporary Amendment Changes to Evals (7.A)