### PR TITLE
Remove Freshman Project

### DIFF
--- a/articles.tex
+++ b/articles.tex
@@ -688,9 +688,6 @@ Occasionally, Temporary Amendments may become permanent through a referendum, wh
 \asection{Changes to Evaluations}
 During the 2018-2019 period the following will supercede the text otherwise found in this document.
 \asubsection{Changes}
-\asubsubsection{Removal of Introductory Project}
-\ref{The Introductory Project} will no longer be a requirement as described in \ref{The Introductory Process}. 
-Additionally, \ref{Introductory Executive Board} will no longer be elected or perform any duties during the described period. 
 \asubsubsection{Change of Packet Percentage}
 \ref{Creation of Accounts} currently stipulates that Introductory Members must acquire 60\% (rounded up to the nearest whole person) of required signatures (excluding those of Resident members who have not passed a Membership Evaluation) in the Introductory Packet or successfully complete Introductory Evaluations. 
 During the described period, the percentage of required signatures in the Introductory Packet will be increased to 75\%. 

--- a/bylaws.tex
+++ b/bylaws.tex
@@ -149,24 +149,6 @@ The Introductory Process is designed to provide an easy means for Introductory M
 \bsubsection{The Evaluation Period}
 The Process lasts between six (6) and ten (10) weeks, starting when the Evaluations Director initiates it.
 The Executive Board may hold a closed ballot Simple Majority vote to extend the Introductory Process.
-\bsubsection{The Introductory Project}
-Introductory members are expected to demonstrate initiative and an ability to work well in a group environment through the Introductory Project.
-\bsubsection{Introductory Executive Board}
-An Introductory Executive Board is elected by the Introductory Members to lead and manage the project, represent the introductory project participants to House, and evaluate participants based on their contribution to the project.
-The Introductory Executive Board consists of three members:
-\begin{itemize}
-	\item A President, who leads the project and acts as primary representative to House through weekly status reports at House Meeting.
-	\item A Vice President, who assists the President in leadership and representation.
-	\item A Treasurer, who manages the finances for the project.
-\end{itemize}
-Introductory Members also elect a Secretary to take notes, and any number of additional non-voting leaders may be elected to take on project-specific tasks.
-\bsubsubsection{The Project}
-The Project is an annual fundraising event that takes place in the first semester of the Introductory Process.
-All of the proceeds go to a charity chosen in advance by the participants.
-The Executive Board is encouraged to discuss the Project and following an open ballot Simple Majority Vote, may choose to intervene in the Introductory Project if the Project does not appear to fulfill requirements.
-\bsubsubsection{Introductory Project Advisors}
-The Evaluations Director may choose between one (1) and three (3) House members to be Introductory Project Advisors.
-The advisors assist in organizing the participants at the beginning of the Introductory Project and thereafter act as a resource to keep the Project running smoothly.
 \bsubsection{The Introductory Packet}
 Each Introductory Process participant, after the first week, is given two (2) weeks to return a document that should contain the following:
 \begin{itemize}
@@ -182,7 +164,6 @@ Before the end of the Process, an Introductory Member is expected to:
 \begin{itemize}
 \item Attend all House meetings during the process
 \item Complete the Introductory Packet
-\item Be an active participant in the Introductory Project
 \item Attend at least one House directorship meeting for each week of the process (including permanent and Ad-Hoc directorship meetings)
 \item Attend at least one House social event during the process
 \item Attend at least two seminars relating to computing or electronics


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
After this year without freshman project, and years of discussing removing it, I believe it is time to remove it altogether with or without the temporary amendment passing at the end of the year.