### PR TITLE
Remove the Temporary Amendment

### DIFF
--- a/articles.tex
+++ b/articles.tex
@@ -680,27 +680,4 @@ The Judicial Board will be responsible for making all necessary inquiries into t
 The Judicial Board may present an official ruling following the Judicial Investigation.
 This ruling may be appealed in the same manner as an Executive Board decision \ref{Appeals}.
 
-% ARTICLE VII - TEMPORARY AMENDMENTS
-\article{Temporary Amendments}
-In the case that an amendment should be temporary, the amendment's changes should be listed here. 
-Each of these amendments is given a designated period of time, and will cease to exist immediately following the end of the period.
-Occasionally, Temporary Amendments may become permanent through a referendum, which is described in detail as part of each Temporary Amendment. 
-\asection{Changes to Evaluations}
-During the 2018-2019 period the following will supercede the text otherwise found in this document.
-\asubsection{Changes}
-\asubsubsection{Removal of Introductory Project}
-\ref{The Introductory Project} will no longer be a requirement as described in \ref{The Introductory Process}. 
-Additionally, \ref{Introductory Executive Board} will no longer be elected or perform any duties during the described period. 
-\asubsubsection{Change of Packet Percentage}
-\ref{Creation of Accounts} currently stipulates that Introductory Members must acquire 60\% (rounded up to the nearest whole person) of required signatures (excluding those of Resident members who have not passed a Membership Evaluation) in the Introductory Packet or successfully complete Introductory Evaluations. 
-During the described period, the percentage of required signatures in the Introductory Packet will be increased to 75\%. 
-\asubsubsection{Changes to Packet Times}
-Introductory Members will recieve \ref{The Introductory Packet} following the House Meeting or Evaluations Directorship meeting of the second week of each semester. 
-Each Introductory Member will submit their packet at the end of week 3. 
-\asubsubsection{Evaluation Period}
-During the described period, the \ref{The Introductory Process} will begin during the first week of each semester.
-The Executive Board may hold a Simple Majority vote to extend the Introductory Process or the Introductory Packet during the described period.
-Additionally, \ref{Introductory Evaluation} occurs between the sixth and tenth week of each semester. 
-\subsubsection{Referendum}
-During the last house meeting of the second semester of the described period, a Two-Thirds vote is held, and if it passes, \ref{Changes to Evaluations} becomes permanent. 
 \end{document}


### PR DESCRIPTION
The temporary amendment was taken apart bit by bit until all the useful parts of it were gone. All that remained was the ability to make temporary amendment, made the packet percentage to get an account higher, and disallowed intro members from reapplying/applying past the first week of each semester. I'd like to propose we don't cause this semester's intro members to go through a half-deconstructed process which we will get rid of entirely at the last HM of the semester. Just end it now.

Check one:
- [X ] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

