### PR TITLE
Remove unneccessary enumeration from Introductory Packet requirements

### DIFF
--- a/bylaws.tex
+++ b/bylaws.tex
@@ -150,14 +150,11 @@ The Introductory Process is designed to provide an easy means for Introductory M
 The Process lasts between six (6) and ten (10) weeks, starting when the Evaluations Director initiates it.
 The Executive Board may hold a closed ballot Simple Majority vote to extend the Introductory Process.
 \bsubsection{The Introductory Packet}
-Each Introductory Process participant, after the first week, is given two (2) weeks to return a document that should contain the following:
+Each Introductory Process participant, after the first week, is given two (2) weeks to return a document that should contain a signature from all Active members, all Introductory Resident members, and ten (10) of any combination of the following:
 \begin{itemize}
-	\item A signature from all Active members, all Introductory Resident members, and ten (10) of any combination of the following:
-	\begin{itemize}
-		\item Alumni members
-		\item Honorary members
-		\item Advisory members
-	\end{itemize}
+	\item Alumni members
+	\item Honorary members
+	\item Advisory members
 \end{itemize}
 \bsubsection{Expectations of an Introductory Member}
 Before the end of the Process, an Introductory Member is expected to:


### PR DESCRIPTION
Check one:
- [ ] Semantic Change: something about the meaning of the text is different
- [X] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

Removes unnecessary nested enumeration from the Introductory Packet requirements section.