### PR TITLE
Allow Evaluations Director to extend an Introductory Packet

### DIFF
--- a/bylaws.tex
+++ b/bylaws.tex
@@ -159,6 +159,7 @@ Each Introductory Process participant, after the first week, is given two (2) we
 		\item Advisory members
 	\end{itemize}
 \end{itemize}
+At the discretion of the Evaluations Director, any Introductory Packet may be extended to accommodate extenuating circumstances.
 \bsubsection{Expectations of an Introductory Member}
 Before the end of the Process, an Introductory Member is expected to:
 \begin{itemize}


### PR DESCRIPTION
Check one:
- [X] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

Allows the Evaluations Director to extend an Introductory Packet to accommodate extenuating circumstances. This brings the Constitution up-to-date with the processes we already have in place.