### PR TITLE
Remove Temporary Amendment 2: Electric Boogaloo

### DIFF
--- a/articles.tex
+++ b/articles.tex
@@ -679,25 +679,4 @@ The Judicial Board will be responsible for making all necessary inquiries into t
 \asection{Judicial Ruling}
 The Judicial Board may present an official ruling following the Judicial Investigation.
 This ruling may be appealed in the same manner as an Executive Board decision \ref{Appeals}.
-
-% ARTICLE VII - TEMPORARY AMENDMENTS
-\article{Temporary Amendments}
-In the case that an amendment should be temporary, the amendment's changes should be listed here. 
-Each of these amendments is given a designated period of time, and will cease to exist immediately following the end of the period.
-Occasionally, Temporary Amendments may become permanent through a referendum, which is described in detail as part of each Temporary Amendment. 
-\asection{Changes to Evaluations}
-During the 2018-2019 period the following will supercede the text otherwise found in this document.
-\asubsection{Changes}
-\asubsubsection{Change of Packet Percentage}
-\ref{Creation of Accounts} currently stipulates that Introductory Members must acquire 60\% (rounded up to the nearest whole person) of required signatures (excluding those of Resident members who have not passed a Membership Evaluation) in the Introductory Packet or successfully complete Introductory Evaluations. 
-During the described period, the percentage of required signatures in the Introductory Packet will be increased to 75\%. 
-\asubsubsection{Changes to Packet Times}
-Introductory Members will recieve \ref{The Introductory Packet} following the House Meeting or Evaluations Directorship meeting of the second week of each semester. 
-Each Introductory Member will submit their packet at the end of week 3. 
-\asubsubsection{Evaluation Period}
-During the described period, the \ref{The Introductory Process} will begin during the first week of each semester.
-The Executive Board may hold a Simple Majority vote to extend the Introductory Process or the Introductory Packet during the described period.
-Additionally, \ref{Introductory Evaluation} occurs between the sixth and tenth week of each semester. 
-\subsubsection{Referendum}
-During the last house meeting of the second semester of the described period, a Two-Thirds vote is held, and if it passes, \ref{Changes to Evaluations} becomes permanent. 
 \end{document}

--- a/bylaws.tex
+++ b/bylaws.tex
@@ -147,8 +147,8 @@ Funds allocated for a project not spent by the end of the Standard Operating Ses
 \bsection{The Introductory Process}
 The Introductory Process is designed to provide an easy means for Introductory Members to meet existing House members, learn House history, demonstrate their involvement potential to House, and allow existing House members to evaluate them for Active Membership.
 \bsubsection{The Evaluation Period}
-The Process lasts between six (6) and ten (10) weeks, starting when the Evaluations Director initiates it.
-The Executive Board may hold a closed ballot Simple Majority vote to extend the Introductory Process.
+The Process will begin between the first and fourth week of each semester, then last between six (6) and ten (10) weeks, starting when the Evaluations Director initiates it.
+The Executive Board may hold a closed ballot Simple Majority vote to extend the Introductory Process or the Introductory Packet.
 \bsubsection{The Introductory Packet}
 Each Introductory Process participant, after the first week, is given two (2) weeks to return a document that should contain the following:
 \begin{itemize}
@@ -172,7 +172,7 @@ Before the end of the Process, an Introductory Member is expected to:
 
 \bsubsection{Introductory Evaluation}
 The Introductory Evaluation is the process by which House chooses which Introductory Members to extend an offer of full Resident or Non-Resident Membership.
-Occurs once per academic year as part of the Introductory Process.
+Occurs between the sixth and tenth week of each semester.
 \bsubsubsection{Voting}
 On a member by member basis, this evaluation process determines if each Introductory member has successfully completed the Introductory Process requirements \ref{Expectations of an Introductory Member}.
 A Simple Majority vote with a quorum of two-thirds of the Total Number of Possible Votes is required for the evaluation to be valid.


### PR DESCRIPTION
Check one:
- [X] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

Removes the Temporary Amendment section entirely (see #143 for additional context), but retains a modified version of the Introductory Process timing change to allow for a larger application window without bringing back full rolling admissions.

Also allows us to have more than one Introductory Evaluations per year. 😂