### PR TITLE
Elections Must Be Held for the Executive Board

### DIFF
--- a/articles.tex
+++ b/articles.tex
@@ -534,7 +534,7 @@ The duties and responsibilities of a vacated office are assumed by the Chairman 
 The vote of a vacated Executive Board position shall be cast as an abstention in all Executive Board matters where this vote is required to be cast.
 
 \asection{Delaying an Election}
-During a House Meeting prior to the election, the Chairman may chair a fifty percent vote to postpone the election by a specified time period. See \ref{Fifty Vote}.
+During a House Meeting prior to the election, the Chairman may chair a fifty percent vote to postpone the election by a specified time period. See \ref{Fifty Percent}.
 If the vote fails, the election must be held on normal time.
 
 \asection{Impeachment}

--- a/articles.tex
+++ b/articles.tex
@@ -524,9 +524,12 @@ The Executive Board may choose to select a current voting Executive Board member
 The selection process can be an informal appointment, or follow an election process similar to other voting Executive Board positions.
 
 \asection{Resignations}
+\asection{Resignations}
 An Executive Board Member may resign their position by submitting in writing the reason for resignation to the House Chairman.
 The resignation will be read at the following House Meeting and become effective at that time.
-The office will become vacant and the selection process for a new member as described in section \ref{Appointment of an Interim Director} will begin at that time. Following a resignation, an election must be held for the position vacated within two weeks from when the resignation took place. The Chairman may chair an immediate fifty percent vote \ref{\ref{Fifty Percent} to postpone the election by a specified time period with a spoken reason. The vote may not take place for elections for year end elections.
+The office will become vacant and the selection process for a new member as described in section \ref{Appointment of an Interim Director} will begin at that time. 
+Following a resignation, an election must be held for the position vacated within two weeks from when the resignation took place.
+To postpone such an election, the Chairman may chair an Immediate Simple Majority Vote \ref{Immediate Vote} \ref{Simple Majority} during a House Meeting prior to the election to delay the election by a specified amount of time.
 
 \asection{Appointment of an Interim Director}
 The duties and responsibilities of a vacated office are assumed by the Chairman or by an Active member that is appointed at the Chairman's discretion until the new member takes office.
@@ -618,7 +621,7 @@ The Vote Counters then tally the results.
 For constitutional modification, candidate selection, and officer removal votes, the voting period must be at least forty-eight (48) hours in length.
 For any other type of vote, the voting period must be at least twenty-four (24) hours.
 The minimum length of the voting period may be explicitly lengthened, but never shortened, in the text describing the actual vote.
-\asubsection}
+\asubsection{Immediate Vote}
 \asubsubsection{Method of Vote}
 The person chairing the vote will state all possible ways to vote, then call out each possibility one at a time.
 The chairing member will count the number of members casting their immediate vote for that possibility.

--- a/articles.tex
+++ b/articles.tex
@@ -527,7 +527,7 @@ The selection process can be an informal appointment, or follow an election proc
 An Executive Board Member may resign their position by submitting in writing the reason for resignation to the House Chairman.
 The resignation will be read at the following House Meeting and become effective at that time.
 The office will become vacant and the selection process for a new member as described in section \ref{Appointment of an Interim Director} will begin at that time. 
-Following the resignation, an election must be held for the position vaccated within 2 house meetings of the time the position was vaccated.
+Following a resignation, an election must be held for the position vaccated within 2 house meetings of the house meeting the position was vaccated.
 
 \asection{Appointment of an Interim Director}
 The duties and responsibilities of a vacated office are assumed by the Chairman or by an Active member that is appointed at the Chairman's discretion until the new member takes office.

--- a/articles.tex
+++ b/articles.tex
@@ -527,7 +527,8 @@ The selection process can be an informal appointment, or follow an election proc
 An Executive Board Member may resign their position by submitting in writing the reason for resignation to the House Chairman.
 The resignation will be read at the following House Meeting and become effective at that time.
 The office will become vacant and the selection process for a new member as described in section \ref{Appointment of an Interim Director} will begin at that time. 
-Following a resignation, an election must be held for the position vacated within two weeks from when the resignation took place.
+Following a resignation, an election must be held for the position vacated within two weeks from when the resignation took place. 
+If necessary, the Chairman may bring a vote and chair the vote during before an election deadline to delay the election by a specified time and the vote will qualify as a fifty percent vote. 
 
 \asection{Appointment of an Interim Director}
 The duties and responsibilities of a vacated office are assumed by the Chairman or by an Active member that is appointed at the Chairman's discretion until the new member takes office.

--- a/articles.tex
+++ b/articles.tex
@@ -526,11 +526,12 @@ The selection process can be an informal appointment, or follow an election proc
 \asection{Resignations}
 An Executive Board Member may resign their position by submitting in writing the reason for resignation to the House Chairman.
 The resignation will be read at the following House Meeting and become effective at that time.
-The office will become vacant and the selection process for a new member as described in section \ref{Appointment of an Interim Director} will begin at that time.
+The office will become vacant and the selection process for a new member as described in section \ref{Appointment of an Interim Director} will begin at that time. 
+Following the resignation, an election must be held for the position vaccated within 2 house meetings of the time the position was vaccated.
 
 \asection{Appointment of an Interim Director}
 The duties and responsibilities of a vacated office are assumed by the Chairman or by an Active member that is appointed at the Chairman's discretion until the new member takes office.
-The vote of a vacated Executive Board position shall be cast as an abstention in all Executive Board matters where this vote is required to be cast.
+The vote of a vacated Executive Board position shall be cast as an abstention in all Executive Board matters where this vote is required to be cast. 
 
 \asection{Impeachment}
 \begin{enumerate}

--- a/articles.tex
+++ b/articles.tex
@@ -527,7 +527,7 @@ The selection process can be an informal appointment, or follow an election proc
 An Executive Board Member may resign their position by submitting in writing the reason for resignation to the House Chairman.
 The resignation will be read at the following House Meeting and become effective at that time.
 The office will become vacant and the selection process for a new member as described in section \ref{Appointment of an Interim Director} will begin at that time. 
-Following a resignation, an election must be held for the position vacated within two house meetings from when the resignation took place.
+Following a resignation, an election must be held for the position vacated within two weeks from when the resignation took place.
 
 \asection{Appointment of an Interim Director}
 The duties and responsibilities of a vacated office are assumed by the Chairman or by an Active member that is appointed at the Chairman's discretion until the new member takes office.

--- a/articles.tex
+++ b/articles.tex
@@ -527,7 +527,7 @@ The selection process can be an informal appointment, or follow an election proc
 An Executive Board Member may resign their position by submitting in writing the reason for resignation to the House Chairman.
 The resignation will be read at the following House Meeting and become effective at that time.
 The office will become vacant and the selection process for a new member as described in section \ref{Appointment of an Interim Director} will begin at that time. 
-Following a resignation, an election must be held for the position vacated within 2 house meetings of the house meeting the position was vacated.
+Following a resignation, an election must be held for the position vacated within two house meetings from when the resignation took place.
 
 \asection{Appointment of an Interim Director}
 The duties and responsibilities of a vacated office are assumed by the Chairman or by an Active member that is appointed at the Chairman's discretion until the new member takes office.

--- a/articles.tex
+++ b/articles.tex
@@ -528,7 +528,7 @@ An Executive Board Member may resign their position by submitting in writing the
 The resignation will be read at the following House Meeting and become effective at that time.
 The office will become vacant and the selection process for a new member as described in section \ref{Appointment of an Interim Director} will begin at that time. 
 Following a resignation, an election must be held for the position vacated within two weeks from when the resignation took place. 
-If necessary, the Chairman may bring a vote and chair the vote during before an election deadline to delay the election by a specified time with a specific reason presented at house meeting; the vote will qualify as a fifty percent vote. 
+If necessary, the Chairman may chair a vote during before an election deadline to delay the election by a specified time with a specific reason presented at house meeting; the vote will qualify as a fifty percent vote. See fifty percent vote \ref{Fifty Percent}.
 
 \asection{Appointment of an Interim Director}
 The duties and responsibilities of a vacated office are assumed by the Chairman or by an Active member that is appointed at the Chairman's discretion until the new member takes office.

--- a/articles.tex
+++ b/articles.tex
@@ -524,7 +524,6 @@ The Executive Board may choose to select a current voting Executive Board member
 The selection process can be an informal appointment, or follow an election process similar to other voting Executive Board positions.
 
 \asection{Resignations}
-\asection{Resignations}
 An Executive Board Member may resign their position by submitting in writing the reason for resignation to the House Chairman.
 The resignation will be read at the following House Meeting and become effective at that time.
 The office will become vacant and the selection process for a new member as described in section \ref{Appointment of an Interim Director} will begin at that time. 

--- a/articles.tex
+++ b/articles.tex
@@ -527,7 +527,7 @@ The selection process can be an informal appointment, or follow an election proc
 An Executive Board Member may resign their position by submitting in writing the reason for resignation to the House Chairman.
 The resignation will be read at the following House Meeting and become effective at that time.
 The office will become vacant and the selection process for a new member as described in section \ref{Appointment of an Interim Director} will begin at that time. 
-Following a resignation, an election must be held for the position vaccated within 2 house meetings of the house meeting the position was vaccated.
+Following a resignation, an election must be held for the position vacated within 2 house meetings of the house meeting the position was vacated.
 
 \asection{Appointment of an Interim Director}
 The duties and responsibilities of a vacated office are assumed by the Chairman or by an Active member that is appointed at the Chairman's discretion until the new member takes office.

--- a/articles.tex
+++ b/articles.tex
@@ -526,16 +526,11 @@ The selection process can be an informal appointment, or follow an election proc
 \asection{Resignations}
 An Executive Board Member may resign their position by submitting in writing the reason for resignation to the House Chairman.
 The resignation will be read at the following House Meeting and become effective at that time.
-The office will become vacant and the selection process for a new member as described in section \ref{Appointment of an Interim Director} will begin at that time. 
-Following a resignation, an election must be held for the position vacated within two weeks from when the resignation took place. 
+The office will become vacant and the selection process for a new member as described in section \ref{Appointment of an Interim Director} will begin at that time. Following a resignation, an election must be held for the position vacated within two weeks from when the resignation took place. The Chairman may chair an immediate fifty percent vote \ref{\ref{Fifty Percent} to postpone the election by a specified time period with a spoken reason. The vote may not take place for elections for year end elections.
 
 \asection{Appointment of an Interim Director}
 The duties and responsibilities of a vacated office are assumed by the Chairman or by an Active member that is appointed at the Chairman's discretion until the new member takes office.
 The vote of a vacated Executive Board position shall be cast as an abstention in all Executive Board matters where this vote is required to be cast.
-
-\asection{Delaying an Election}
-During a House Meeting prior to the election, the Chairman may chair a immediate fifty percent vote to postpone the election by a specified time period. See \ref{Fifty Percent}. This vote cannot take place for elections taking place for the next standard operating year's Executive Board.
-If the vote fails, the election must be held on normal time.
 
 \asection{Impeachment}
 \begin{enumerate}
@@ -623,7 +618,7 @@ The Vote Counters then tally the results.
 For constitutional modification, candidate selection, and officer removal votes, the voting period must be at least forty-eight (48) hours in length.
 For any other type of vote, the voting period must be at least twenty-four (24) hours.
 The minimum length of the voting period may be explicitly lengthened, but never shortened, in the text describing the actual vote.
-\asubsection{Immediate Vote}
+\asubsection}
 \asubsubsection{Method of Vote}
 The person chairing the vote will state all possible ways to vote, then call out each possibility one at a time.
 The chairing member will count the number of members casting their immediate vote for that possibility.

--- a/articles.tex
+++ b/articles.tex
@@ -533,9 +533,9 @@ Following a resignation, an election must be held for the position vacated withi
 The duties and responsibilities of a vacated office are assumed by the Chairman or by an Active member that is appointed at the Chairman's discretion until the new member takes office.
 The vote of a vacated Executive Board position shall be cast as an abstention in all Executive Board matters where this vote is required to be cast.
 
-\asection{Delaying Election}
-If necessary, the Chairman may chair a vote before an election deadline at house meeting to delay the election by a specified time with a specific reason presented at house meeting; the vote will qualify as a fifty percent vote. See fifty percent vote \ref{Fifty Percent}. 
-If the vote fails, the election deadline already established will stay in effect.
+\asection{Delaying an Election}
+During a House Meeting prior to the election, the Chairman may chair a fifty percent vote to postpone the election by a specified time period. See \ref{Fifty Vote}.
+If the vote fails, the election must be held on normal time.
 
 \asection{Impeachment}
 \begin{enumerate}

--- a/articles.tex
+++ b/articles.tex
@@ -528,7 +528,7 @@ An Executive Board Member may resign their position by submitting in writing the
 The resignation will be read at the following House Meeting and become effective at that time.
 The office will become vacant and the selection process for a new member as described in section \ref{Appointment of an Interim Director} will begin at that time. 
 Following a resignation, an election must be held for the position vacated within two weeks from when the resignation took place. 
-If necessary, the Chairman may bring a vote and chair the vote during before an election deadline to delay the election by a specified time and the vote will qualify as a fifty percent vote. 
+If necessary, the Chairman may bring a vote and chair the vote during before an election deadline to delay the election by a specified time with a specific reason presented at house meeting; the vote will qualify as a fifty percent vote. 
 
 \asection{Appointment of an Interim Director}
 The duties and responsibilities of a vacated office are assumed by the Chairman or by an Active member that is appointed at the Chairman's discretion until the new member takes office.

--- a/articles.tex
+++ b/articles.tex
@@ -534,7 +534,7 @@ The duties and responsibilities of a vacated office are assumed by the Chairman 
 The vote of a vacated Executive Board position shall be cast as an abstention in all Executive Board matters where this vote is required to be cast.
 
 \asection{Delaying an Election}
-During a House Meeting prior to the election, the Chairman may chair a fifty percent vote to postpone the election by a specified time period. See \ref{Fifty Percent}.
+During a House Meeting prior to the election, the Chairman may chair a immediate fifty percent vote to postpone the election by a specified time period. See \ref{Fifty Percent}. This vote cannot take place for elections taking place for the next standard operating year's Executive Board.
 If the vote fails, the election must be held on normal time.
 
 \asection{Impeachment}

--- a/articles.tex
+++ b/articles.tex
@@ -528,11 +528,14 @@ An Executive Board Member may resign their position by submitting in writing the
 The resignation will be read at the following House Meeting and become effective at that time.
 The office will become vacant and the selection process for a new member as described in section \ref{Appointment of an Interim Director} will begin at that time. 
 Following a resignation, an election must be held for the position vacated within two weeks from when the resignation took place. 
-If necessary, the Chairman may chair a vote before an election deadline at house meeting to delay the election by a specified time with a specific reason presented at house meeting; the vote will qualify as a fifty percent vote. See fifty percent vote \ref{Fifty Percent}.
 
 \asection{Appointment of an Interim Director}
 The duties and responsibilities of a vacated office are assumed by the Chairman or by an Active member that is appointed at the Chairman's discretion until the new member takes office.
 The vote of a vacated Executive Board position shall be cast as an abstention in all Executive Board matters where this vote is required to be cast.
+
+\asection{Delaying Election}
+If necessary, the Chairman may chair a vote before an election deadline at house meeting to delay the election by a specified time with a specific reason presented at house meeting; the vote will qualify as a fifty percent vote. See fifty percent vote \ref{Fifty Percent}. 
+If the vote fails, the election deadline already established will stay in effect.
 
 \asection{Impeachment}
 \begin{enumerate}

--- a/articles.tex
+++ b/articles.tex
@@ -531,7 +531,7 @@ Following a resignation, an election must be held for the position vaccated with
 
 \asection{Appointment of an Interim Director}
 The duties and responsibilities of a vacated office are assumed by the Chairman or by an Active member that is appointed at the Chairman's discretion until the new member takes office.
-The vote of a vacated Executive Board position shall be cast as an abstention in all Executive Board matters where this vote is required to be cast. 
+The vote of a vacated Executive Board position shall be cast as an abstention in all Executive Board matters where this vote is required to be cast.
 
 \asection{Impeachment}
 \begin{enumerate}

--- a/articles.tex
+++ b/articles.tex
@@ -528,7 +528,7 @@ An Executive Board Member may resign their position by submitting in writing the
 The resignation will be read at the following House Meeting and become effective at that time.
 The office will become vacant and the selection process for a new member as described in section \ref{Appointment of an Interim Director} will begin at that time. 
 Following a resignation, an election must be held for the position vacated within two weeks from when the resignation took place. 
-If necessary, the Chairman may chair a vote during before an election deadline to delay the election by a specified time with a specific reason presented at house meeting; the vote will qualify as a fifty percent vote. See fifty percent vote \ref{Fifty Percent}.
+If necessary, the Chairman may chair a vote before an election deadline at house meeting to delay the election by a specified time with a specific reason presented at house meeting; the vote will qualify as a fifty percent vote. See fifty percent vote \ref{Fifty Percent}.
 
 \asection{Appointment of an Interim Director}
 The duties and responsibilities of a vacated office are assumed by the Chairman or by an Active member that is appointed at the Chairman's discretion until the new member takes office.


### PR DESCRIPTION
Check one:
- [X] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

We should have a process which requires elections to be held once someone resigns instead of having a possible interim director forever at the discretion of the Executive Board.
