### PR TITLE
Outdated Housing Points Reference

### DIFF
--- a/bylaws.tex
+++ b/bylaws.tex
@@ -299,7 +299,7 @@ They still have access to all other privileges associated with their membership,
 \bsection{Housing Priority System}
 The Housing Priority System is a means for determining the priority a House member has in a Housing issue such as Single Room Assignment or the Assignment of Available Housing.
 The member with top priority is the member with on-floor status and the most Housing Priority Points.
-Housing points are accumulated during the Housing Evaluation described in \ref{Housing Evaluation}.
+Housing points are accumulated by the end of the year in accordance with the Evaluations Director. \ref{Housing Points}.
 \\* \\*
 In the event of a tie, the members will be approached simultaneously and if they are unable to decide fairly between themselves, the assignment of priority will be made by random selection of the tied members.
 \bsubsection{Single Room Assignments}


### PR DESCRIPTION
Check one:
- [ ] Semantic Change: something about the meaning of the text is different
- [x] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
If I'm reading this correctly... this is simply referring to winter evals that doesn't exist anymore.
