### PR TITLE
Capitalise 'standard operating session'

### DIFF
--- a/articles.tex
+++ b/articles.tex
@@ -298,7 +298,7 @@ A leave of absence can be extended by submitting a new request.
 A member may return from a leave of absence whenever they choose to.
 When a member wishes to return, they must in writing notify a staff member of Residence Life, excluding student employees, to end their leave of absence.
 \asubsection{Modified Evaluations}
-A member may request their evaluation period to be extended by the duration of the leave or to end of the standard operating session, whichever comes first.
+A member may request their evaluation period to be extended by the duration of the leave or to end of the Standard Operating Session, whichever comes first.
 \asubsection{Leave of Absence for an Executive Board Member}
 The duties and responsibilities of an Executive Board Member on leave are assumed using the process defined in Section \ref{Appointment of an Interim Director} until the member returns from their leave.
 Upon returning, the member may assume their position and the interim director is removed.
@@ -342,7 +342,7 @@ However, the Chairman and at least two-thirds of the Voting Members must be pres
 \asubsection{Responsibilities of the Executive Board}
 \begin{enumerate}
 	\item To hold a weekly meeting specific to their responsibilities and submit notes to the House
-	\item To meet, as an Executive Board, at least weekly during the standard operating session, as defined in \ref{Standard Operating Session} to discuss and report the operations of the House
+	\item To meet, as an Executive Board, at least weekly during the Standard Operating Session, as defined in \ref{Standard Operating Session} to discuss and report the operations of the House
 	\item To report pertinent information to House members at the following House Meeting
 	\item To maintain records of the goals defined by each previous Executive Board
 	\item To act as a Judicial Board as defined in \ref{Judicial}
@@ -350,7 +350,7 @@ However, the Chairman and at least two-thirds of the Voting Members must be pres
 	\item To make the final vote regarding conditionals and appeals as defined in \ref{Membership Evaluation}
 	\item To respect the privacy of House members confiding in the Executive Board, barring situations related to endangerment of oneself or others, sexual assault, or in the case of a Judicial Board
 	\item To publish a document at the end of each semester to all Members stating House’s accomplishments of that semester
-	\item To review and update the Constitution at the end of each standard operating session, as defined in \ref{Standard Operating Session}
+	\item To review and update the Constitution at the end of each Standard Operating Session, as defined in \ref{Standard Operating Session}
 		The constitution should remain up to date with current practices.
 \end{enumerate}
 


### PR DESCRIPTION
'standard operating session' doesen't refer to the Standard Operating
Session.

Check one:
- [ ] Semantic Change: something about the meaning of the text is different
- [x] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Capitalise ‘Standard Operating Session’ so it matches the bylaws.
