### PR TITLE
Remove the notarize reference

### DIFF
--- a/articles.tex
+++ b/articles.tex
@@ -3,7 +3,6 @@
 %  However, if a sub part is moved to a different part, its references must be
 %  changed.
 % -This document must be ratified by the House (as per the Constitution),
-%  then printed, signed, notarized, and placed in the House filing cabinet
 %  if changes are to be officialized.
 
 \documentclass{article}

--- a/bylaws.tex
+++ b/bylaws.tex
@@ -3,7 +3,6 @@
 %  However, if a sub part is moved to a different part, its references must be
 %  changed.
 % -This document must be ratified by the House (as per the Constitution),
-%  then printed, signed, notarized, and placed in the House filing cabinet
 %  if changes are to be finalized.
 
 \documentclass{article}


### PR DESCRIPTION
We don't require this per the constitution

Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s): Per the constitution, we no longer need to print, sign, notarize, and place the document in the cabinet. But it's a file change, so it's semantic.

