### PR TITLE
Simplify the requirements for nominations

### DIFF
--- a/articles.tex
+++ b/articles.tex
@@ -489,13 +489,13 @@ The following special cases cover the operation of a dual directorship:
 \asubsection{Selection of the Chairman, Evaluations Director, Social Director(s), Financial Director, House Improvements Director, House History Director, Research and Development Director(s)}
 \begin{enumerate}
 	\item The opening of the Executive Board position(s) is announced at a House meeting and nominations for the position are taken for a minimum of a seventy-two hour period.
-		Any House member may nominate any eligible member or pair of members where appropriate for a Directorship.
-	\item The candidates meeting the qualifications of the office they were nominated for, will be notified of their nomination.
+		Any House member may nominate any member or pair of members where appropriate for a Directorship.
+	\item The candidates will be notified of their nomination.
 		Each candidate is given a minimum of twenty-four hour period to accept or decline the nomination.
 		A list of all nominees who have accepted their nominations will be posted shortly thereafter.
 	\item Each candidate will be given an equal amount of time before the House to present their platform of candidacy.
 	\item Ballots will then be distributed and voting will be open for a minimum of a forty-eight hour period.
-		The Ballots will list, in random order, all of the candidates for a given office with a means to indicate the selection of one of the candidates.
+		The Ballots will list, in random order, all of the candidates who are qualified for a given office with a means to indicate the selection of one of the candidates.
 		In addition, an area will be provided to indicate a write-in selection of a candidate.
 	\item At the end of the voting period, the Chairman will terminate voting by collecting the ballot box and the votes shall be counted as stated in \ref{Alternative Vote}.
 	\item The winners are determined via the process described in \ref{Alternative Vote}.
@@ -503,7 +503,7 @@ The following special cases cover the operation of a dual directorship:
 		All winners are notified of their election.
 		If the position is currently vacant, the winner immediately assumes office.
 		If not, the winner will assume office at the end of the current term (\ref{Term}).
-		Any office whose winner declines the election, or whose winner was a write-in candidate who does not fulfill the requirements of the elected office, shall have their votes redistributed in the same process as a loser in \ref{Alternative Vote}.
+		Any office whose winner declines the election, or whose winner does not fulfill the requirements of the elected office, shall have their votes redistributed in the same process as a loser in \ref{Alternative Vote}.
 \end{enumerate}
 \asubsection{Selection of the Operational Communications Director}
 \begin{enumerate}


### PR DESCRIPTION
By current practice, we don't restrict nomination only to qualified
members, so we should update that, so we can bring up candidates and
determine whether their merit should override the qualifications of a
seat.

Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

This is primarily to update to current practice. If we are going to bring up a candidate who isn't qualified and consider the possibility of an override of the qualifications, we allow them to be nominated before we do discussion and voting. This means we can bring up overrides at a House Meeting before ballots are distributed.

This change removes the requirement to be qualified from nominations and places it instead with the inclusion in ballots and the determination of winners.
