### PR TITLE
Automatically pass All Green at Spring Evals

### DIFF
--- a/bylaws.tex
+++ b/bylaws.tex
@@ -251,6 +251,7 @@ All members may notify the evaluations director before the end of the academic y
 The Membership Evaluation process occurs once per academic year.
 It is performed as part of the Evaluation Process that takes place during the spring semester to comply with RIT Housing deadlines.
 \bsubsubsection{Voting}
+Any Active Member who has completed all of the requirements as defined in \ref{Expectations of House Members} at the beginning of the Membership Evaluation passes their Membership Evaluation without being voted on or evaluated by the quorum.
 All Active Members who have not recieved an exemption from the Executive Board prior to the Membership Evaluation will be evaluated on a Member by Member basis by a quorum of Active Members.
 Evaluations will hold members to the objective requirements defined in \ref{Expectations of House Members} and determine which members may continue as an Active Member in the following Standard Operating Session.
 Exceptions to the requirements may be made, and House may choose any of the Outcomes for each Member, even if the Member being evaluated has not completed all of their requirements.


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

All members who have completed all of their requirements will automatically pass their Membership Evaluation.

This stems from recent conversations, where it has sounded as though we should never not be passing a member who has objectively completed their requirements.