### PR TITLE
Standardises the spelling of Ad-Hoc

### DIFF
--- a/articles.tex
+++ b/articles.tex
@@ -311,7 +311,7 @@ Its purpose is to provide leadership and direction for the House, to oversee the
 It is composed of the seven permanent directors and the Chairman.
 \\*\\*
 There is one permanent directorship for each major aspect of the government of the House and each one is chaired by an Executive Board member.
-Ad-hoc directorships are created on an as-needed basis.
+Ad-Hoc directorships are created on an as-needed basis.
 They are generally very task oriented and are chaired by a House member.
 A directorship has some jurisdiction in its area of interest and often is responsible for the day-to-day decisions regarding its area of interest.
 Any large expenditures or large effect decisions must be brought before the entire House
@@ -330,7 +330,7 @@ Any large expenditures or large effect decisions must be brought before the enti
 \begin{itemize}
 	\item Chairman
 	\item House Secretary
-	\item Ad Hoc Director(s)
+	\item Ad-Hoc Director(s)
 \end{itemize}
 \asection{Closed Executive Board}
 Closed Executive Board Meetings are open only to the Chairman, Voting Members of the Executive Board, and those with the express permission of the Executive Board.
@@ -437,7 +437,7 @@ However, the Chairman and at least two-thirds of the Voting Members must be pres
 	\item To record all votes cast during House Meetings and Open Executive Board Meetings
 \end{enumerate}
 
-\asubsection{Responsibilities of Ad Hoc Directorships}
+\asubsection{Responsibilities of Ad-Hoc Directorships}
 \begin{enumerate}
 	\item Ad-Hoc Directorships are responsible for the task for which they were created
 	\item Any responsibilities budgets or finances for the Ad-Hoc Directorship are placed upon the assigned director
@@ -464,7 +464,7 @@ However, the Chairman and at least two-thirds of the Voting Members must be pres
 	\item A Root Type Person cannot be the director if they currently hold any other voting Executive Board Position.
 \end{enumerate}
 
-\asubsection{Qualifications to be the House Secretary or an Ad Hoc Director}
+\asubsection{Qualifications to be the House Secretary or an Ad-Hoc Director}
 \begin{enumerate}
 \item Candidates must be Active Members
 \end{enumerate}
@@ -514,9 +514,9 @@ The following special cases cover the operation of a dual directorship:
 	\item All current Executive Board Voting Members must be present during the discussion and voting period unless that member is a candidate for the position, in which case the member is absent and their vote is abstained.
 		A simple majority Executive Board vote, as described in \ref{Simple Majority}, is taken to determine whether the candidate is selected for the position.
 \end{enumerate}
-\asubsection{Selection of Ad Hoc Directors}
+\asubsection{Selection of Ad-Hoc Directors}
 \begin{enumerate}
-	\item When the Executive Board or a group of House members feels an Ad-hoc Directorship is necessary, they present their plans to the Executive Board and the Executive Board decides by simple majority vote whether directorship status is granted.
+	\item When the Executive Board or a group of House members feels an Ad-Hoc Directorship is necessary, they present their plans to the Executive Board and the Executive Board decides by simple majority vote whether directorship status is granted.
 	\item When the Ad-Hoc Directorship is granted status, a director is appointed, and duties, budgetary, and membership considerations are defined.
 \end{enumerate}
 \asubsection{Selection of the House Secretary}
@@ -558,8 +558,8 @@ The vote of a vacated Executive Board position shall be cast as an abstention in
 \item The newly selected officers shall begin their terms on June 1 of that year and their terms shall end on May 31 of the following year.
 \item The term of an officer will be abbreviated due to resignation, impeachment, or change in membership status.
 \item Officers elected or selected during the course of the year due to an abbreviated term of the previous officer shall hold office until the end of the normal term.
-\item When the task of an Ad Hoc Directorship has been completed, the directorship dissolves.
-	When an Ad Hoc Director resigns, the directorship dissolves and must be reinstated with a new director.
+\item When the task of an Ad-Hoc Directorship has been completed, the directorship dissolves.
+	When an Ad-Hoc Director resigns, the directorship dissolves and must be reinstated with a new director.
 \end{enumerate}
 
 \asection{Appeals}


### PR DESCRIPTION
Check one:
- [ ] Semantic Change: something about the meaning of the text is different
- [X] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

It was very inconsistent so now it's `Ad-Hoc` everywhere.