### PR TITLE
Allow Evaluations Appeals

### DIFF
--- a/articles.tex
+++ b/articles.tex
@@ -563,7 +563,7 @@ The vote of a vacated Executive Board position shall be cast as an abstention in
 \end{enumerate}
 
 \asection{Appeals}
-Decisions made by the Executive Board may be appealed and overturned.
+Decisions made by the Executive Board or Evaluations results may be appealed and overturned.
 To initiate an appeal, a member must have the support of three voting members of the Executive Board, or a petition with the signatures of one-third of Active Members.
 After the appeal is presented, a Simple Majority vote is held by the Executive Board whether or not to overturn and reevaluate the decision.
 If the vote passes, the Executive Board may discuss and make a new ruling by another Simple Majority vote.

--- a/bylaws.tex
+++ b/bylaws.tex
@@ -188,6 +188,10 @@ House may choose any of the Outcomes for each member.
 		When the deadline expires, the conditional will be brought before the Executive Board who will assess its completeness.
 		A conditional member who does not meet these additional requirements forfeits membership.
 \end{enumerate}
+\bsubsection{Appeals Process}
+If a member disagrees with the outcome of any evaluation, (e.g. is not asked to return to the House for the following year) and wishes to appeal the decision, they may do so as stated in \ref{Appeals}.
+\\* \\*
+If the member is still unsatisfied after being heard by the Executive Board, the appeal may be brought to the attention of the ResLife Advisor.
 \bsection{Selection Processes}
 \renewcommand{\theenumi}{\alph{enumi}} % For this section, we want items to use letters
 \bsubsection{Selection Process for Students Attending RIT for at Least One Semester}


### PR DESCRIPTION
Check one:
- [X] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

This updates to current practice, and allows all evaluations decisions
to be appealed.
