### PR TITLE
Add combined membership agreement and code of conduct

### DIFF
--- a/membership-agreement.tex
+++ b/membership-agreement.tex
@@ -58,8 +58,7 @@ limited to):
 \end{flushleft}
 
 \begin{itemize}
-    \item The use of sexualized language or imagery and unwelcome sexual
-          attention or advances
+    \item Inappropriate or unwelcome sexual comments, attention or advances
     \item Inflammatory behavior, insulting/derogatory comments, and personal
           or political attacks
     \item Public or private harassment

--- a/membership-agreement.tex
+++ b/membership-agreement.tex
@@ -126,8 +126,9 @@ membership in Computer Science House:
     \item I will abide by the guidelines and rules set forth in the CSH
           Computer Code of Conduct regarding CSH services and member privileges for
           the entirety of my membership.
-    \item If I am to fail in the evaluations process, I will revoke my spot
-          in the housing queue and on the housing board.
+    \item If I am to fail in the evaluations process, I understand that I will be
+          removed from any housing queue or board. If I am already registered to live
+          on CSH the following year, I understand my spot will not be revoked.
 \end{enumerate}
 
 I understand that should I violate any of the above conditions, I may be

--- a/membership-agreement.tex
+++ b/membership-agreement.tex
@@ -1,0 +1,143 @@
+\documentclass{article}
+\usepackage{hyperref}
+\usepackage{showkeys}
+\usepackage{enumerate}
+
+% Title page information
+\title{
+\textbf{Computer Science House}\\
+Membership Agreement and Code of Conduct}
+\author{}
+
+% Last Modified Date
+\newcommand{\datechanged}{Last Updated: \today}
+\date{\datechanged}
+
+% Fix margins
+\setlength{\evensidemargin}{0in}
+\setlength{\oddsidemargin}{0in}
+\setlength{\textwidth}{6.5in}
+\setlength{\topmargin}{0in}
+\setlength{\textheight}{8.5in}
+
+\pagestyle{myheadings}
+\markright{{\rm CSH Membership Agreement \hfill \datechanged \hfill Page }}
+
+\begin{document}
+\maketitle
+
+\section*{Our Pledge}
+
+In the interest of fostering an open and welcoming environment, we as
+members of Computer Science House pledge to make membership and
+participation in our community a harassment-free experience for everyone,
+regardless of age, body size, disability, ethnicity, sex characteristics,
+gender identity and expression, level of experience, education,
+socio-economic status, nationality, personal appearance, race, religion,
+or sexual identity and orientation. In the interest of being good
+citizens in the wider RIT community, we also pledge to abide by the
+\href{https://www.rit.edu/studentaffairs/studentconduct/code-conduct}
+{RIT Student Code of Conduct} and uphold its values.
+
+\section*{Our Standards}
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+\begin{itemize}
+    \item Using welcoming and inclusive language
+    \item Being respectful of differing viewpoints and experiences
+    \item Gracefully accepting constructive criticism
+    \item Focusing on what is best for the community
+    \item Showing empathy towards other community members
+\end{itemize}
+
+\begin{flushleft}
+Examples of unacceptable behavior by participants include (but are not
+limited to):
+\end{flushleft}
+
+\begin{itemize}
+    \item The use of sexualized language or imagery and unwelcome sexual
+          attention or advances
+    \item Inflammatory behavior, insulting/derogatory comments, and personal
+          or political attacks
+    \item Public or private harassment
+    \item Publishing others’ private information, such as a physical or
+          electronic address, without explicit permission
+\end{itemize}
+
+\section*{Our Responsibilities}
+
+Computer Science House’s Executive Board (E-board) is responsible for
+clarifying the standards of acceptable behavior and are expected to take
+appropriate and fair corrective action in response to any instances of
+unacceptable behavior. E-Board has the right and responsibility to remove,
+edit, or reject posts, comments, or other media that is not aligned to this
+Code of Conduct from official CSH communication or collaboration platforms,
+or to ban temporarily or permanently any member from these platforms for
+other behaviors that they deem inappropriate, threatening, offensive, or
+harmful.
+
+\section*{Scope}
+
+This Code of Conduct applies within all CSH spaces, and it also applies when
+an individual is representing CSH or its community in public spaces. Examples
+of representing CSH include using an official CSH e-mail address, posting via
+an official social media account, or acting as an appointed representative at
+an online or offline event. Representation of CSH may be further defined and
+clarified by E-Board.
+
+\section*{Enforcement}
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting CSH E-board at
+\href{mailto:eboard@csh.rit.edu}{eboard@csh.rit.edu}. All complaints will
+be reviewed and investigated and will result in a response that is deemed
+necessary and appropriate to the circumstances. E-board is expected to
+reasonably protect the privacy of the reporter of an incident, but may
+escalate the report to res-life or other RIT faculty at their discretion.
+Further details of specific enforcement policies may be posted separately.
+Members who do not follow or enforce the Code of Conduct in good faith may
+face temporary or permanent repercussions as determined by E-Board.
+
+\section*{Attribution}
+
+This Code of Conduct is adapted from the
+\href{https://www.contributor-covenant.org/}{Contributor Covenant},
+version 1.4, available at \\
+\href{https://www.contributor-covenant.org/version/1/4/code-of-conduct.html}
+{https://www.contributor-covenant.org/version/1/4/code-of-conduct.html} \\
+For answers to common questions about this code of conduct, see
+\href{https://www.contributor-covenant.org/faq}
+{https://www.contributor-covenant.org/faq}.
+
+\section*{Commitment}
+
+I, \makebox[2.5in]{\hrulefill}, hereby agree to the following conditions for
+membership in Computer Science House:
+
+\begin{enumerate}
+    \item I will abide by the qualifications and expectations of a member,
+          as well as follow the general rules of the House, as outlined in the CSH
+          Constitution for the entirety of my membership.
+    \item I commit to making Computer Science House a friendly and welcoming
+          community by embracing the values set forth in this Code of Conduct.
+    \item I will abide by the guidelines and rules set forth in the CSH
+          Computer Code of Conduct regarding CSH services and member privileges for
+          the entirety of my membership.
+    \item If I am to fail in the evaluations process, I will revoke my spot
+          in the housing queue and on the housing board.
+\end{enumerate}
+
+I understand that should I violate any of the above conditions, I may be
+subject to sanctions as outlined in the CSH Constitution.
+
+\noindent
+\begin{tabular}{ll}
+\\[8ex]
+\makebox[3.5in]{\hrulefill} & \makebox[2.5in]{\hrulefill}\\
+Signature & Date\\
+\end{tabular}
+
+\end{document}


### PR DESCRIPTION
This PR combines CSH's past [membership agreement] with a new Code of Conduct describing our expectations for members' behaviors. Additionally, it is a step in the direction of consolidating all official CSH documents into this Constitution repository.

[membership agreement]: https://github.com/computersciencehouse/membershipagreement

(I'll post a link to the rendered document as soon as I figure it out)