### PR TITLE
Rm housing evals

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -673,7 +673,7 @@ They still have access to all other privileges associated with their membership,
 \asubsubsection{Housing Priority System}
 The Housing Priority System is a means for determining the priority a House member has in a Housing issue such as Single Room Assignment or the Assignment of Available Housing.
 The member with top priority is the member with on-floor status and the most Housing Priority Points.
-Housing Priority Points are accumulated once per Operating Session at the conclusion of the Membership Evaluation. Each Active Member with On-Floor Status who passes the Membership Evaluation is granted one (1) Housing Priority Point.
+Housing Priority Points are accumulated once per Operating Session at the conclusion of the Membership Evaluation. Each Active Member with On-Floor Status who passes the Membership Evaluation is granted two (2) Housing Priority Points.
 \\* \\*
 In the event of a tie, the members will be approached simultaneously and if they are unable to decide fairly between themselves, the assignment of priority will be made by random selection of the tied members.
 \asubsubsubsection{Single Room Assignments}

--- a/constitution.tex
+++ b/constitution.tex
@@ -673,11 +673,11 @@ They still have access to all other privileges associated with their membership,
 \asubsubsection{Housing Priority System}
 The Housing Priority System is a means for determining the priority a House member has in a Housing issue such as Single Room Assignment or the Assignment of Available Housing.
 The member with top priority is the member with on-floor status and the most Housing Priority Points.
-Housing points are accumulated during the Housing Evaluation described in \ref{Housing Evaluation}.
+Housing Priority Points are accumulated once per Operating Session at the conclusion of the Membership Evaluation. Each Active Member with On-Floor Status who passes the Membership Evaluation is granted one (1) Housing Priority Point.
 \\* \\*
 In the event of a tie, the members will be approached simultaneously and if they are unable to decide fairly between themselves, the assignment of priority will be made by random selection of the tied members.
 \asubsubsubsection{Single Room Assignments}
-When a single room on the House becomes available it is offered to the member who carries the highest Housing Priority as defined in By-Law V, Section H.
+When a single room on the House becomes available it is offered to the member who carries the highest Housing Priority as defined in \ref{Housing Priority System}.
 If that House member declines the option, it will be offered to the member with the next highest Housing Priority.
 This process continues until a member selects to move into the single room.
 Once in a single room, a House member retains the assignment until voluntarily giving it up.

--- a/constitution.tex
+++ b/constitution.tex
@@ -678,6 +678,7 @@ Housing Priority Points are accumulated once per Operating Session at the conclu
 In the event of a tie, the members will be approached simultaneously and if they are unable to decide fairly between themselves, the assignment of priority will be made by random selection of the tied members.
 \asubsubsubsection{Single Room Assignments}
 When a single room on the House becomes available it is offered to the member who carries the highest Housing Priority as defined in \ref{Housing Priority System}.
+In the event of a tie, the members will be approached simultaneously and if they are unable to decide fairly between themselves, the assignment of priority will be made by random selection of the tied members.
 If that House member declines the option, it will be offered to the member with the next highest Housing Priority.
 This process continues until a member selects to move into the single room.
 Once in a single room, a House member retains the assignment until voluntarily giving it up.


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

Deletes bad references to Housing Evals, makes housing points automatic. Also updates constitution to current process.