### PR TITLE
Capitalize Introductory Evaluations

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -570,7 +570,7 @@ House may choose any of the Outcomes for each member.
 	Then a simple majority vote, of attending members, is held on whether or not to accept the person as an Introductory Member.
 \end{enumerate}
 Note: Most membership privileges do not initiate until successful completion of the introductory process.
-This means that until the member has passed the introductory evaluation, the member does NOT have the right to vote on House issues and does NOT count towards quorum.
+This means that until the member has passed the Introductory Evaluation, the member does NOT have the right to vote on House issues and does NOT count towards quorum.
 The member does, however, have the right to use Computer Science House's facilities.
 The member must also pay dues.
 \\* \\*
@@ -583,7 +583,7 @@ Additional Note: No hazing shall occur at any time during the Selection Process 
 		An additional subset will be given Off-Floor status, but otherwise receive the same privileges and responsibilities.
 \end{enumerate}
 Note: Most membership privileges do not initiate until successful completion of the introductory process.
-This means that until the member has passed the introductory evaluation, the member does NOT have the right to vote on House issues and does NOT count towards quorum.
+This means that until the member has passed the Introductory Evaluation, the member does NOT have the right to vote on House issues and does NOT count towards quorum.
 The member does, however, have the right to use Computer Science House's facilities.
 The member must also pay dues.
 \\* \\*


### PR DESCRIPTION
Check one:
- [ ] Semantic Change: something about the meaning of the text is different
- [X] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s): Capitalizing Introductory Evaluations because it's a proper term
