### PR TITLE
Add a missing 'and' to conditional description

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -556,7 +556,7 @@ House may choose any of the Outcomes for each member.
 		In addition, the participant is asked to find alternative housing as soon as possible in accordance with all applicable Residence Life policies regarding room changes.
 	\item An Introductory member may be given a conditional to complete as a means of making up for missing requirements.
 		A conditional may be proposed by any member present at the Introductory Evaluation and, if it is approved by the Evaluations Director, is then voted on by House.
-		Each conditional consists of a set of additional requirements a deadline for completing them.
+		Each conditional consists of a set of additional requirements and a deadline for completing them.
 		When the deadline expires, the conditional will be brought before the Executive Board who will assess its completeness.
 		A conditional member who does not meet these additional requirements forfeits membership.
 \end{enumerate}


### PR DESCRIPTION
Check one:
- [ ] Semantic Change: something about the meaning of the text is different
- [X] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s): The description for a conditional was missing an "and." This adds it

