### PR TITLE
Correct Makefile to handle references

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ PDFFILES=$(TEXFILES:.tex=.pdf)
 
 all:
 	$(PDFLATEX) `git log -1 --date=short --format=format:'\newcommand{\RevisionInfo}{Revision %h on %ad}'` '\input{constitution.tex}'
+	$(PDFLATEX) `git log -1 --date=short --format=format:'\newcommand{\RevisionInfo}{Revision %h on %ad}'` '\input{constitution.tex}'
 
 clean:
 	$(RM) $(PDFFILES)


### PR DESCRIPTION
Check one:
- [ ] Semantic Change: something about the meaning of the text is different
- [x] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
The makefile needs to build twice so that previous references are understood.
