### PR TITLE
Fixes Active Membership Requirements and Packet

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -542,8 +542,7 @@ Before the end of the Process, an Introductory Member is expected to:
 \end{itemize}
 
 \asubsubsubsection{Introductory Evaluation}
-The Introductory Evaluation is the process by which House chooses which Introductory Members to extend an offer of Active
-Membership.
+The Introductory Evaluation is the process by which House chooses which Introductory Members to extend an offer of Active Membership.
 Occurs between the sixth and tenth week of each semester.
 \asubsubsubsubsection{Voting}
 On a member by member basis, this evaluation process determines if each Introductory member has successfully completed the Introductory Process requirements \ref{Expectations of an Introductory Member}.

--- a/constitution.tex
+++ b/constitution.tex
@@ -222,7 +222,8 @@ For the duration of an absence, a member:
 \end{itemize}
 \asubsection{Active Membership Resignations}
 An Active member may resign by submitting, in writing, the reason for resignation to the Chairperson, or Evaluations Director.
-Instead of forfeiting membership, Active members who resign may elect to become Alumni defined in \ref{Alumni Membership Selection}.
+Instead of forfeiting membership, Active members who resign may elect to become Alumni defined in \ref{Alumni Membership Selection}. As defined, a member who has not passed at least one Membership Evaluation cannot become an Alumni and will
+no longer have any membership standing with House.
 The resignation will take effect immediately and an announcement will be made at the following House Meeting.
 \asubsection{Active Membership Term}
 Active Membership shall last until the member: resigns or changes membership status.

--- a/constitution.tex
+++ b/constitution.tex
@@ -210,7 +210,7 @@ Active Members receive the right to:
 Active Members currently on co-op forfeit their right to vote on house issues, and likewise do not count towards quorum.
 Exceptions may be made at the discretion of the Evaluations Director.
 \asubsection{Active Membership Evaluations}
-Active Members are evaluated semi-annually through the Evaluation Process as described in \ref{Evaluations Processes}.
+Active Members are evaluated annually through the Evaluation Process as described in \ref{Evaluations Processes}.
 Failure of the Evaluation Process could result in the member being asked to find alternative housing as soon as possible in accordance with all applicable Residence Life policies regarding room changes.
 \asubsection{Active Membership Leave of Absence}
 An Active member may at any time request a leave of absence using the process described in \ref{Leave of Absence}.

--- a/constitution.tex
+++ b/constitution.tex
@@ -523,7 +523,7 @@ The Introductory Process is designed to provide an easy means for Introductory M
 The Process will begin between the first and fourth week of each semester, then last between six (6) and ten (10) weeks, starting when the Evaluations Director initiates it.
 The Executive Board may hold a closed ballot Simple Majority vote to extend the Introductory Process or the Introductory Packet.
 \asubsubsubsection{The Introductory Packet}
-Each Introductory Process participant, after the first week, is given two (2) weeks to return a document that should contain a signature from all Active members whom passed a Membership Evaluation, all Introductory Resident members, and ten (10) of any combination of the following:
+Each Introductory Process participant, after the first week, is given two (2) weeks to return a document that should contain a signature from all Active members whom have passed a Membership Evaluation, all Introductory Resident members, and ten (10) of any combination of the following:
 \begin{itemize}
 	\item Alumni members
 	\item Honorary members

--- a/constitution.tex
+++ b/constitution.tex
@@ -523,7 +523,7 @@ The Introductory Process is designed to provide an easy means for Introductory M
 The Process will begin between the first and fourth week of each semester, then last between six (6) and ten (10) weeks, starting when the Evaluations Director initiates it.
 The Executive Board may hold a closed ballot Simple Majority vote to extend the Introductory Process or the Introductory Packet.
 \asubsubsubsection{The Introductory Packet}
-Each Introductory Process participant, after the first week, is given two (2) weeks to return a document that should contain a signature from all Active members, all Introductory Resident members, and ten (10) of any combination of the following:
+Each Introductory Process participant, after the first week, is given two (2) weeks to return a document that should contain a signature from all Active members whom passed a Membership Evaluation, all Introductory Resident members, and ten (10) of any combination of the following:
 \begin{itemize}
 	\item Alumni members
 	\item Honorary members
@@ -542,7 +542,8 @@ Before the end of the Process, an Introductory Member is expected to:
 \end{itemize}
 
 \asubsubsubsection{Introductory Evaluation}
-The Introductory Evaluation is the process by which House chooses which Introductory Members to extend an offer of full Resident or Non-Resident Membership.
+The Introductory Evaluation is the process by which House chooses which Introductory Members to extend an offer of Active
+Membership.
 Occurs between the sixth and tenth week of each semester.
 \asubsubsubsubsection{Voting}
 On a member by member basis, this evaluation process determines if each Introductory member has successfully completed the Introductory Process requirements \ref{Expectations of an Introductory Member}.

--- a/constitution.tex
+++ b/constitution.tex
@@ -186,7 +186,7 @@ Introductory membership shall last until the end of the introductory process, at
 
 \asection{Active Membership}
 \asubsection{Active Membership Qualifications}
-Active Membership is open to all students currently enrolled at the Rochester Institute of Technology who have passed their last Introductory Evaluation or their most recent Membership Evaluation.
+Active Membership is open to all students currently enrolled at the Rochester Institute of Technology who have passed their most recent Introductory Evaluation or their most recent Membership Evaluation.
 \asubsection{Active Membership Selection}
 Qualifying members may self-select into Active Membership by paying dues to the Financial Director and notifying the Evaluations Director.
 \\*\\*

--- a/constitution.tex
+++ b/constitution.tex
@@ -186,8 +186,7 @@ Introductory membership shall last until the end of the introductory process, at
 
 \asection{Active Membership}
 \asubsection{Active Membership Qualifications}
-Active Membership is open to all students currently enrolled at the Rochester Institute of Technology who have passed their
-last Introductory Evaluation or their most recent Membership Evaluation.
+Active Membership is open to all students currently enrolled at the Rochester Institute of Technology who have passed their last Introductory Evaluation or their most recent Membership Evaluation.
 \asubsection{Active Membership Selection}
 Qualifying members may self-select into Active Membership by paying dues to the Financial Director and notifying the Evaluations Director.
 \\*\\*

--- a/constitution.tex
+++ b/constitution.tex
@@ -221,8 +221,8 @@ For the duration of an absence, a member:
 \end{itemize}
 \asubsection{Active Membership Resignations}
 An Active member may resign by submitting, in writing, the reason for resignation to the Chairperson, or Evaluations Director.
-Instead of forfeiting membership, Active members who resign may elect to become Alumni defined in \ref{Alumni Membership Selection}. As defined, a member who has not passed at least one Membership Evaluation cannot become an Alumni and will
-no longer have any membership standing with House.
+Instead of forfeiting membership, Active members who resign may elect to become Alumni defined in \ref{Alumni Membership Selection}. 
+As defined, a member who has not passed at least one Membership Evaluation cannot become an Alumni and will no longer have any membership standing with House.
 The resignation will take effect immediately and an announcement will be made at the following House Meeting.
 \asubsection{Active Membership Term}
 Active Membership shall last until the member: resigns or changes membership status.

--- a/constitution.tex
+++ b/constitution.tex
@@ -186,7 +186,8 @@ Introductory membership shall last until the end of the introductory process, at
 
 \asection{Active Membership}
 \asubsection{Active Membership Qualifications}
-Active Membership is open to all students currently enrolled at the Rochester Institute of Technology who have passed the Introductory Evaluation and their most recent Membership Evaluation.
+Active Membership is open to all students currently enrolled at the Rochester Institute of Technology who have passed their
+last Introductory Evaluation or their most recent Membership Evaluation.
 \asubsection{Active Membership Selection}
 Qualifying members may self-select into Active Membership by paying dues to the Financial Director and notifying the Evaluations Director.
 \\*\\*


### PR DESCRIPTION
Active Membership is now awarded upon intro-members if they pass 10-weeks.

Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

