### PR TITLE
Don't elect OpComm, Ad Hocs, or the Secretary

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -817,12 +817,12 @@ The following special cases cover the operation of a dual directorship:
 The Executive Board may choose to select a current voting Executive Board member, or to select any interested Active member, as House Secretary.
 The selection process can be an informal appointment, or follow an election process similar to other voting Executive Board positions.
 
-\asection{Resignations}
+\asection{Executive Board Resignations}
 An Executive Board Member may resign their position by submitting in writing the reason for resignation to the House Chairperson.
 The resignation will be read at the following House Meeting and become effective at that time.
 The office will become vacant and the selection process for a new member as described in section \ref{Appointment of an Interim Director} will begin at that time.
-Following a resignation, an election must be held for the position vacated within two weeks from when the resignation took place.
-To postpone such an election, the Chairman may chair an Immediate Simple Majority Vote \ref{Immediate Vote} \ref{Simple Majority} during a House Meeting prior to the election to delay the election by a specified amount of time.
+Following a resignation, the Selection process, as defined in \ref{Selection}, of a replacement for the position vacated must begin within two weeks from when the resignation took place.
+To postpone such a Selection, the Chairperson may chair an Immediate Simple Majority Vote \ref{Immediate Vote} \ref{Simple Majority} during a House Meeting prior to the beginning of the Selection process to delay the Selection process by a specified amount of time.
 
 \asection{Appointment of an Interim Director}
 The duties and responsibilities of a vacated office are assumed by the Chairperson or by an Active member that is appointed at the Chairperson's discretion until the new member takes office.


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
#181 and #148 would require an election in the event of the resignation of the OpComm Director, the Secretary, or any AdHoc Director. This requires their replacement to be selected via the process we usually use to select that position.
