### PR TITLE
Remove outdated 'Housing Points' and cleanup Housing Priority

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -617,8 +617,6 @@ All Executive Board members are expected to attend the Semi-Annual Evaluations M
 \\* \\*
 At the beginning of any Evaluation Process listed herein, the Evaluations Director must read the sections of the Computer Science House Constitution and By-Laws used during the respective Evaluation Process.
 It is incumbent upon each House member to provide the Evaluation Director with whatever information they feel is necessary to ensure an accurate evaluation.
-\asubsubsubsection{Housing Points}
-All members may notify the evaluations director before the end of the academic year that they would like to receive two housing points for use in the next academic year.
 \asubsubsubsection{Membership Evaluation}
 The Membership Evaluation process occurs once per academic year.
 It is performed as part of the Evaluation Process that takes place during the spring semester to comply with RIT Housing deadlines.
@@ -668,12 +666,12 @@ To be granted On-Floor status, members may notify the Evaluations Director that 
 The Evaluations Director will then bring them up for vote at the next meeting.
 \asubsubsubsection{Off-Floor Status}
 Members with Off-Floor status do not have the right to live on the floor.
-They still have access to all other privileges associated with their membership, and may still accumulate Housing Points.
+They still have access to all other privileges associated with their membership, and may still accumulate Housing Priority Points.
 
 \asubsubsection{Housing Priority System}
 The Housing Priority System is a means for determining the priority a House member has in a Housing issue such as Single Room Assignment or the Assignment of Available Housing.
 The member with top priority is the member with on-floor status and the most Housing Priority Points.
-Housing Priority Points are accumulated once per Operating Session at the conclusion of the Membership Evaluation. Each Active Member with On-Floor Status who passes the Membership Evaluation is granted two (2) Housing Priority Points.
+Housing Priority Points are accumulated once per Operating Session at the conclusion of the Membership Evaluation. Each Active Member who passes the Membership Evaluation is granted two (2) Housing Priority Points.
 \\* \\*
 In the event of a tie, the members will be approached simultaneously and if they are unable to decide fairly between themselves, the assignment of priority will be made by random selection of the tied members.
 \asubsubsubsection{Single Room Assignments}


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

We use the 'Housing Priority System' and 'Housing Priority Points'. We
don't need to also define 'Housing Points' in a different place, with a
conflicting definition.

This PR brings the constitution in line with current practice, and makes the constitution less confusing and self contradictory.
