### PR TITLE
Correct inconsistency in Intro Period extensions

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -521,6 +521,7 @@ The Introductory Process is designed to provide an easy means for Introductory M
 \asubsubsubsection{The Evaluation Period}
 The Process will begin between the first and fourth week of each semester, then last between six (6) and ten (10) weeks, starting when the Evaluations Director initiates it.
 The Executive Board may hold a closed ballot Simple Majority vote to extend the Introductory Process or the Introductory Packet.
+If an Introductory Process is extended, the Introductory Evaluation shall occur at the termination of the extended Process, which may be outside of the period defined in \ref{Introductory Evaluation}.
 \asubsubsubsection{The Introductory Packet}
 Each Introductory Process participant, after the first week, is given two (2) weeks to return a document that should contain a signature from all Active members, all Introductory Resident members, and ten (10) of any combination of the following:
 \begin{itemize}


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

If the Intro Process is extended, that Process's Evaluation may need to occur outside of the 6th and 10th week of the semster.