### PR TITLE
Correct undefined Resignation references

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -775,7 +775,7 @@ Non-voting Executive Board positions (i.e. Ad Hoc Directors) are not restricted 
 The following special cases cover the operation of a dual directorship:
 \begin{itemize}
 	\item If one of the members in a dual directorship resigns the directorship, or for any other reason ends the term of office, the other member in the dual directorship must also step down and the office becomes vacated.
-		The vacated office is then handled like any other vacated office; see \ref{Resignations}.
+		The vacated office is then handled like any other vacated office; see \ref{Executive Board Resignations}.
 	\item During an official Executive Board Vote, each dual directorship member's vote counts for one-half vote in the tallying of votes.
 		The members of the dual directorship need not vote the same way in a vote.
 	\item A member of a dual directorship may not hold any other Executive Board position.
@@ -845,7 +845,7 @@ The vote of a vacated Executive Board position shall be cast as an abstention in
 		A vote equaling or exceeding two-thirds the number of all ballots cast is necessary for the accused officer to be removed from office.
 		If a quorum cannot be reached after two attempts, or the percentage of affirmative votes does not equal or exceed the minimum, impeachment proceedings are dismissed.
 	\item If the percentage of affirmative votes equals or exceeds the minimum the impeached officer is relinquished of their position and any benefits thereof and this position is treated like any other vacated position.
-		A new selection and interim duty fulfillment procedure is followed similar to that of a resignation; see \ref{Resignations}.
+		A new selection and interim duty fulfillment procedure is followed similar to that of a resignation; see \ref{Executive Board Resignations}.
 	\item House Secretary can be impeached according to the above process, or may be dismissed by a Simple Majority vote of the Executive Board.
 \end{enumerate}
 


### PR DESCRIPTION
Check one:
- [ ] Semantic Change: something about the meaning of the text is different
- [x] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

Resignations -> Executive Board Resignations
Fixes undefined label warnings at compile time.
