### PR TITLE
removed requirement for chair and evals to be on floor

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -742,7 +742,6 @@ The following process is used for making changes to the Code of Conduct document
 \asubsection{Qualifications to be the Chairperson, Evaluations Director}
 \begin{enumerate}
 	\item Candidates must be Active Members during the term of office
-	\item Candidates must reside on floor during the term of office
 	\item Candidates must have at least one full semester of House membership as an Active Member
 	\item Elected or selected candidates may not hold a simultaneous voting Executive Board position, and must therefore resign their current position, or the position of Chairperson, should they be elected
 \end{enumerate}


### PR DESCRIPTION
Check one:
- [X ] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Removed requirement for evaluations director and chair to be on floor in order to qualify for the position.
