### PR TITLE
removed requirement for failed intro + active members to move off-floor

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -210,7 +210,6 @@ Active Members currently on co-op forfeit their right to vote on house issues, a
 Exceptions may be made at the discretion of the Evaluations Director.
 \asubsection{Active Membership Evaluations}
 Active Members are evaluated semi-annually through the Evaluation Process as described in \ref{Evaluations Processes}.
-Failure of the Evaluation Process could result in the member being asked to find alternative housing as soon as possible in accordance with all applicable Residence Life policies regarding room changes.
 \asubsection{Active Membership Leave of Absence}
 An Active member may at any time request a leave of absence using the process described in \ref{Leave of Absence}.
 For the duration of an absence, a member:
@@ -553,7 +552,6 @@ House may choose any of the Outcomes for each member.
 \begin{enumerate}
 	\item Introductory Members may be offered Active Membership (\ref{Active Membership}) provided they meet the requirements described in \ref{Expectations of an Introductory Member}, at the discretion of House.
 	\item If an Introductory Member fails to meet the requirements, their membership will be revoked.
-		In addition, the participant is asked to find alternative housing as soon as possible in accordance with all applicable Residence Life policies regarding room changes.
 	\item An Introductory member may be given a conditional to complete as a means of making up for missing requirements.
 		A conditional may be proposed by any member present at the Introductory Evaluation and, if it is approved by the Evaluations Director, is then voted on by House.
 		Each conditional consists of a set of additional requirements and a deadline for completing them.


### PR DESCRIPTION
Check one:
- [X] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Removed reference to failed active and intro members being required to move off-floor. 

This is something house currently does not do and something the SIH reviewers were concerned about.