### PR TITLE
Reword ambiguous membership evaluation

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -624,8 +624,8 @@ The Membership Evaluation process occurs once per academic year.
 It is performed as part of the Evaluation Process that takes place during the spring semester to comply with RIT Housing deadlines.
 \asubsubsubsubsection{Voting}
 All Active Members who have not recieved an exemption from the Executive Board prior to the Membership Evaluation will be evaluated on a Member by Member basis by a quorum of Active Members.
-Evaluations will hold members to the objective requirements defined in \ref{Expectations of House Members} and determine which members may continue as an Active Member in the following Standard Operating Session.
-Exceptions to the requirements may be made, and House may choose any of the Outcomes for each Member, even if the Member being evaluated has not completed all of their requirements.
+The Membership Evaluation shall hold members to the objective requirements defined in \ref{Expectations of House Members} and determine which members may continue as an Active Member in the following Standard Operating Session.
+Exceptions to the requirements may be made, as House may choose any of the Outcomes for each Member, even if the Member being evaluated has not completed all of their requirements.
 These requirements must be completed before the Membership Evaluation occurs.
 A Secret Immediate Simple Majority vote with a Quorum of two-thirds of the Total Number of Possible Votes is required for the evaluation to be valid.
 Neither absentee nor proxy votes are allowed.


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Reduce ambiguity in the membership eval voting section by being more specific.
