### PR TITLE
Return auto pass to the written constitution

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -622,6 +622,7 @@ It is incumbent upon each House member to provide the Evaluation Director with w
 The Membership Evaluation process occurs once per academic year.
 It is performed as part of the Evaluation Process that takes place during the spring semester to comply with RIT Housing deadlines.
 \asubsubsubsubsection{Voting}
+Any Active Member who has completed all of the requirements as defined in \ref{Expectations of House Members} at the beginning of the Membership Evaluation passes their Membership Evaluation without being voted on or evaluated by the quorum.
 All Active Members who have not recieved an exemption from the Executive Board prior to the Membership Evaluation will be evaluated on a Member by Member basis by a quorum of Active Members.
 The Membership Evaluation shall hold members to the objective requirements defined in \ref{Expectations of House Members} and determine which members may continue as an Active Member in the following Standard Operating Session.
 Exceptions to the requirements may be made, as House may choose any of the Outcomes for each Member, even if the Member being evaluated has not completed all of their requirements.


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

We originally introduced auto-pass in #163, which was brought up to vote, and passed.
It seems that when the documents were merged in #172, this addition was lost.

This PR introduces the same wording, in the same sub section. This is exactly the same change as #163, and I believe current practice as of last year.

The original wording of #163 was:
```
All members who have completed all of their requirements will automatically pass their Membership Evaluation.
```
