### PR TITLE
Added fullstop to line 360

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -357,7 +357,7 @@ However, the Chairperson and at least two-thirds of the Voting Members must be p
 	\item To make the final vote regarding conditionals and appeals as defined in \ref{Membership Evaluation}
 	\item To respect the privacy of House members confiding in the Executive Board, barring situations related to endangerment of oneself or others, sexual assault, or in the case of a Judicial Board
 	\item To publish a document at the end of each semester to all Members stating House’s accomplishments of that semester
-	\item To review and update the Constitution at the end of each Standard Operating Session, as defined in \ref{Standard Operating Session}
+	\item To review and update the Constitution at the end of each Standard Operating Session, as defined in \ref{Standard Operating Session}.
 		The constitution should remain up to date with current practices.
 \end{enumerate}
 


### PR DESCRIPTION
Check one:
- [  ] Semantic Change: something about the meaning of the text is different
- [X] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Added a fullstop to line 360 to make sure it's clear that it's two sentences.

