### PR TITLE
allow honorary and advisory members accounts without completion of packet

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -717,12 +717,13 @@ Membership is composed of all Root Type Persons.
 
 \asubsubsection{Creation of Accounts}
 Root Type Persons have the authority to manage user accounts for House systems.
-Before members may receive an account they must:
+Before introductory, active, or alumni members may receive an account they must:
 \renewcommand{\theenumi}{\alph{enumi}} % For this section, we want items to use letters
 \begin{enumerate}
 	\item Sign the Code of Conduct sheets pertaining to the responsible utilization of Computer Science House and Rochester Institute of Technology facilities.
 	\item Obtain greater than or equal to 60\% (rounded up to the nearest whole person) of required signatures (excluding those of Resident members who have not passed a Membership Evaluation) in the Introductory Packet or successfully complete Introductory Evaluations.
 \end{enumerate}
+Accounts for honorary and advisory members may be created at the discretion of the Root Type Persons.
 
 \asubsubsection{Code of Conduct}
 The Code of Conduct located at \url{https://github.com/ComputerScienceHouse/CodeOfConduct} is the canonical Code of Conduct for Computer Science House accounts.


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s): It's dumb that honorary members need to complete packet so this changes that.


