### PR TITLE
Remove spending committees

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -499,12 +499,10 @@ Money allocated for Accum and off-floor member dues is deposited into the CSH Ac
 
 \asubsubsection{Expenditure Approval}
 All House expenditures must be approved by both the Financial Director and the appropriate Director (from whose budget the funds will be drawn).
-Single expenditures may not exceed seventy-five dollars (\$75) and total expenditures may not exceed one-hundred dollars (\$100).
-A total expenditure is defined as all the funds drawn for a specific event, project, piece of equipment, or service.
+Single expenditures may not exceed five percent of a directorship's budget (5\%) and total expenditures may not exceed ten percent (10\%).
+A single expenditure is defined as one line item on a receipt, and a total expenditure is defined as all the funds drawn for a specific event, project, piece of equipment, or service.
 \\* \\*
 If the above amounts are to be exceeded, the expenditure must be approved by a Simple Majority vote at House meeting before the funds may be appropriated, as defined in \ref{Simple Majority}.
-At the Financial Director's discretion, a Spending Committee meeting may be held in order to approve any purchase exceeding one-hundred dollars (\$100), but not to exceed three-hundred dollars (\$300).
-A quorum of one-quarter the number of current active members is required for the meeting to take place and for any vote to be considered valid, it must be passed by a simple two-thirds majority.
 \\*\\*
 For expenditures exceeding \$300 in total funding, a Complete Project Proposal must be presented to House at a House meeting.
 This proposal includes the project budget, inventory of required resources, and a timeline for completion.

--- a/constitution.tex
+++ b/constitution.tex
@@ -504,7 +504,7 @@ A single expenditure is defined as one line item on a receipt, and a total expen
 \\* \\*
 If the above amounts are to be exceeded, the expenditure must be approved by a Simple Majority vote at House meeting before the funds may be appropriated, as defined in \ref{Simple Majority}.
 \\*\\*
-For expenditures exceeding \$300 in total funding, a Complete Project Proposal must be presented to House at a House meeting.
+For expenditures exceeding ten percent (10\%) of a directorship's budget, a Complete Project Proposal must be presented to House at a House meeting.
 This proposal includes the project budget, inventory of required resources, and a timeline for completion.
 \\* \\*
 If an appropriate Directorship cannot be determined for an expenditure, it is to be brought up for approval at House meeting as a Miscellaneous expenditure and approved by a simple majority vote, regardless of the amount.


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

This PR attempts to address a few things. First and most importantly, the notion of a spending committee is unnecessary bureaucracy that we should trim from the spending process.

## Delete spending committees

Currently, the process is for spending money from a directorship's budget is (roughly) the following:
1. Get permission from the directorship who's budget the purchase will fall under
2. Get approval from financials to spend the money
3. Request approval from RIT (Currently res life, subject to change)
3b. Wait probably a few days to get approval from RIT (I have a lot of complaints about this part but this is a PR not a discourse post)
4. If the purchase is between $100-$300, convince 1/4 of quorum (Currently ~10 ish active voting members, which is tough to come by pre-ten weeks) to gather somewhere and say whether or not you're allowed to use your budget
5. Pick up the pro card from RIT during business hours, or if it's an online purchase hope that you can buy said thing from an RIT approved vendor, otherwise more bureaucracy incoming
6. Actually go spend money on some purchase
7. Return the pro card and any relevant receipts to RIT by 2pm the following day (If online purchase, skip this step)

Removing the spending committee would delete step 4 from the process. My argument is that there are already several layers of approval already baked into the process of spending CSH funds and that a spending committee does not accomplish it's goal of preventing directorships for making purchases that they should not be making, and instead is just a big waste of time.

It's also been particularly difficult when attempting to plan events whose cost scales with the number of attendees when we get one number on an interest form and then right before the event a ton of people sign up. It's tough to know which events we'd need to do comittees for and which we wouldn't, and we're discouraged from simply always holding spending committees because of the hassle of organizing them. A point to the contrary is that we could make sign up forms for every event with a deadline and say that anyone who doesn't sign up by the deadline will have to pay for themselves. While there is definitely merit in this idea, it would likely have the direct result of reducing attendance which is something we generally try to avoid as much as possible.

## Define "single expenditures"

Second, I added a definition to what a `single expenditure` is, as previously we only had a definition for what a group expenditure is. Definitely open to modifying that definition, it just seemed non-obvious to determine what a single expenditure is based on the definition provided.

## Change the $300 limit to a percentage of a directorship's budget
Third, I changed the value of what the single/group expenditures to sort of fill in the gaps of where the spending committee left off. Rather than having a fixed value for the distinction between purchases, I opted to include a percentage of the directorship's' budget. Also, I'm totally down to change the exact values, this post is mostly for discussion so I didn't think too hard about the exact numbers.

Pros of this change:
* The amount directorships can spend will change from year to year based on our overall budget
  * While there are some fixed purchases, the vast majority of the purchases we make demonstrate a positive correlation between price and the number of active members. Opcomm will have to buy less hard drives if there's less members making minecraft servers, socials will have to spend less money on welcome back if there's less people eating burgers, etc
* Larger directorships will have higher limits than smaller directorships
  * If smaller budgets like PR are spending more than $40, we probably should know about it. On the other hand, it's hard for socials to make a purchase without spending over $40, and they probably shouldn't have to ask house every time they want to spend money
* While at the end of the day it's still an arbitrary percentage, saying "don't spend more than 10% of your budget in one go" has a pretty clear rationality behind it as opposed to saying "don't spend above the magic number $100 or else," which can be frustrating to members

Cons of this change:
* I'm biased
  * The socials budget is the largest budget, and these changes would make it easier for larger budgets and potentially more restrictive for smaller budgets
* The amount directorships can spend will change from year to year based on our overall budget
  * I definitely think this is more a pro than a con, but there are definitely some fixed costs that we have. Our app store license is always $100 a year regardless of how many members we have(idk if we even pay for that anymore but you get the idea)
  * "Active" members who participate a bunch in csh does not always equal active members who pay dues.
    * The proportion of active alumni to active members can sometimes fluctuate pretty heavily, so having a percentaged based off of the total budget (which consists solely of dues afaik) might not be the best metric
* Directorships would need to be aware of their individual limits and would not just be able to determine if they need a vote on something if it's >$300

tl;dr is spending committees mostly just hinder members trying to do the right thing and in reality don't do anything to prevent directorships from abusing the system if they're so inclined, so we should just get rid of it. Also, having a fixed value be the distinction between needing to vote on a purchase or not sorta sucks and should be replaced with a percentage. 