### PR TITLE
Updated introductory process timeline to new proposal

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -520,7 +520,8 @@ Funds allocated for a project not spent by the end of the Standard Operating Ses
 \asubsubsection{The Introductory Process}
 The Introductory Process is designed to provide an easy means for Introductory Members to meet existing House members, learn House history, demonstrate their involvement potential to House, and allow existing House members to evaluate them for Active Membership.
 \asubsubsubsection{The Evaluation Period}
-The Process will occur either once or twice a semester, at the discretion of the Evaluations Director, and will last for six (6) weeks.
+The Process will occur either once or twice per semester, at the discretion of the Evaluations Director, and will last for six (6) weeks.
+The Process shall be initiated by the Evaluations Director during either the first or second week of each semester.
 The Executive Board may hold a closed ballot Simple Majority vote to extend the Introductory Process or the Introductory Packet.
 If an Introductory Process is extended, the Introductory Evaluation shall occur at the termination of the extended Process, which may be outside of the period defined in \ref{Introductory Evaluation}.
 If deemed necessary by the Evaluations Director, the second intro process must begin within nine (9) days of the first process ending.

--- a/constitution.tex
+++ b/constitution.tex
@@ -520,11 +520,11 @@ Funds allocated for a project not spent by the end of the Standard Operating Ses
 \asubsubsection{The Introductory Process}
 The Introductory Process is designed to provide an easy means for Introductory Members to meet existing House members, learn House history, demonstrate their involvement potential to House, and allow existing House members to evaluate them for Active Membership.
 \asubsubsubsection{The Evaluation Period}
-The Process will occur either once or twice per semester, at the discretion of the Evaluations Director, or by an Executive Board simple majority vote, and will last for six (6) weeks.
+The Process will occur either once or twice per semester, and will last for six (6) weeks.
 The Process shall be initiated by the Evaluations Director during either the first or second week of each semester.
 The Executive Board may hold a closed ballot Simple Majority vote to extend the Introductory Process or the Introductory Packet.
 If an Introductory Process is extended, the Introductory Evaluation shall occur at the termination of the extended Process, which may be outside of the period defined in \ref{Introductory Evaluation}.
-If deemed necessary by the Evaluations Director, the second intro process must begin within nine (9) days of the first process ending.
+If deemed necessary by the Evaluations Director, or by an Executive Board simple majority vote, the second intro process must begin within nine (9) days of the first process ending.
 \asubsubsubsection{The Introductory Packet}
 Each Introductory Process participant, after the first week, is given two (2) weeks to return a document that should contain a signature from all Active members, all Introductory Resident members, and ten (10) of any combination of the following:
 \begin{itemize}

--- a/constitution.tex
+++ b/constitution.tex
@@ -520,10 +520,10 @@ Funds allocated for a project not spent by the end of the Standard Operating Ses
 \asubsubsection{The Introductory Process}
 The Introductory Process is designed to provide an easy means for Introductory Members to meet existing House members, learn House history, demonstrate their involvement potential to House, and allow existing House members to evaluate them for Active Membership.
 \asubsubsubsection{The Evaluation Period}
-The Process will occur either once or twice a semester, and will last for six (6) weeks.
+The Process will occur either once or twice a semester, at the discretion of the Evaluations Director, and will last for six (6) weeks.
 The Executive Board may hold a closed ballot Simple Majority vote to extend the Introductory Process or the Introductory Packet.
 If an Introductory Process is extended, the Introductory Evaluation shall occur at the termination of the extended Process, which may be outside of the period defined in \ref{Introductory Evaluation}.
-The Introductory Process may be held twice a semester at the discretion of the evaluations director. If deemed necessary, the second intro process must begin within nine (9) days of the first process ending.
+If deemed necessary by the Evaluations Director, the second intro process must begin within nine (9) days of the first process ending.
 \asubsubsubsection{The Introductory Packet}
 Each Introductory Process participant, after the first week, is given two (2) weeks to return a document that should contain a signature from all Active members, all Introductory Resident members, and ten (10) of any combination of the following:
 \begin{itemize}

--- a/constitution.tex
+++ b/constitution.tex
@@ -521,10 +521,11 @@ Funds allocated for a project not spent by the end of the Standard Operating Ses
 The Introductory Process is designed to provide an easy means for Introductory Members to meet existing House members, learn House history, demonstrate their involvement potential to House, and allow existing House members to evaluate them for Active Membership.
 \asubsubsubsection{The Evaluation Period}
 The Process will occur either once or twice per semester, and will last for six (6) weeks.
-The Process shall be initiated by the Evaluations Director during either the first or second week of each semester.
+The Process shall be initiated by the Evaluations Director during either the first and second week of each semester.
 The Executive Board may hold a closed ballot Simple Majority vote to extend the Introductory Process or the Introductory Packet.
 If an Introductory Process is extended, the Introductory Evaluation shall occur at the termination of the extended Process, which may be outside of the period defined in \ref{Introductory Evaluation}.
 If deemed necessary by the Evaluations Director, or by an Executive Board simple majority vote, the second intro process must begin within nine (9) days of the first process ending.
+If a second Introductory Process is approved, the Evaluations Director may initiate a new Introductory Packet within the first or second week of the Introductory Process.
 \asubsubsubsection{The Introductory Packet}
 Each Introductory Process participant, after the first week, is given two (2) weeks to return a document that should contain a signature from all Active members, all Introductory Resident members, and ten (10) of any combination of the following:
 \begin{itemize}

--- a/constitution.tex
+++ b/constitution.tex
@@ -520,9 +520,10 @@ Funds allocated for a project not spent by the end of the Standard Operating Ses
 \asubsubsection{The Introductory Process}
 The Introductory Process is designed to provide an easy means for Introductory Members to meet existing House members, learn House history, demonstrate their involvement potential to House, and allow existing House members to evaluate them for Active Membership.
 \asubsubsubsection{The Evaluation Period}
-The Process will begin between the first and fourth week of each semester, then last between six (6) and ten (10) weeks, starting when the Evaluations Director initiates it.
+The Process will begin between the first and second week of each semester, then last six (6) weeks, starting when the Evaluations Director initiates it.
 The Executive Board may hold a closed ballot Simple Majority vote to extend the Introductory Process or the Introductory Packet.
 If an Introductory Process is extended, the Introductory Evaluation shall occur at the termination of the extended Process, which may be outside of the period defined in \ref{Introductory Evaluation}.
+The Introductory Process may be held twice a semester at the discretion of the evaluations director. If the evaluations director deems it necessary, the second intro process must begin within a week of the first process ending, and must last the same six (6) weeks.
 \asubsubsubsection{The Introductory Packet}
 Each Introductory Process participant, after the first week, is given two (2) weeks to return a document that should contain a signature from all Active members, all Introductory Resident members, and ten (10) of any combination of the following:
 \begin{itemize}
@@ -544,7 +545,8 @@ Before the end of the Process, an Introductory Member is expected to:
 
 \asubsubsubsection{Introductory Evaluation}
 The Introductory Evaluation is the process by which House chooses which Introductory Members to extend an offer of full Resident or Non-Resident Membership.
-Occurs between the sixth and tenth week of each semester.
+Occurs during the sixth week of each semester. If the evaluations director chooses to hold a second Introductory Process, the Introductory Evaluation will also occur during the twelfth week of each semester.
+
 \asubsubsubsubsection{Voting}
 On a member by member basis, this evaluation process determines if each Introductory member has successfully completed the Introductory Process requirements \ref{Expectations of an Introductory Member}.
 A Simple Majority vote with a quorum of two-thirds of the Total Number of Possible Votes is required for the evaluation to be valid.

--- a/constitution.tex
+++ b/constitution.tex
@@ -520,7 +520,7 @@ Funds allocated for a project not spent by the end of the Standard Operating Ses
 \asubsubsection{The Introductory Process}
 The Introductory Process is designed to provide an easy means for Introductory Members to meet existing House members, learn House history, demonstrate their involvement potential to House, and allow existing House members to evaluate them for Active Membership.
 \asubsubsubsection{The Evaluation Period}
-The Process will occur either once or twice per semester, at the discretion of the Evaluations Director, and will last for six (6) weeks.
+The Process will occur either once or twice per semester, at the discretion of the Evaluations Director, or by an Executive Board simple majority vote, and will last for six (6) weeks.
 The Process shall be initiated by the Evaluations Director during either the first or second week of each semester.
 The Executive Board may hold a closed ballot Simple Majority vote to extend the Introductory Process or the Introductory Packet.
 If an Introductory Process is extended, the Introductory Evaluation shall occur at the termination of the extended Process, which may be outside of the period defined in \ref{Introductory Evaluation}.

--- a/constitution.tex
+++ b/constitution.tex
@@ -520,10 +520,10 @@ Funds allocated for a project not spent by the end of the Standard Operating Ses
 \asubsubsection{The Introductory Process}
 The Introductory Process is designed to provide an easy means for Introductory Members to meet existing House members, learn House history, demonstrate their involvement potential to House, and allow existing House members to evaluate them for Active Membership.
 \asubsubsubsection{The Evaluation Period}
-The Process will begin between the first and second week of each semester, then last six (6) weeks, starting when the Evaluations Director initiates it.
+The Process will occur either once or twice a semester, and will last for six (6) weeks.
 The Executive Board may hold a closed ballot Simple Majority vote to extend the Introductory Process or the Introductory Packet.
 If an Introductory Process is extended, the Introductory Evaluation shall occur at the termination of the extended Process, which may be outside of the period defined in \ref{Introductory Evaluation}.
-The Introductory Process may be held twice a semester at the discretion of the evaluations director. If the evaluations director deems it necessary, the second intro process must begin within a week of the first process ending, and must last the same six (6) weeks.
+The Introductory Process may be held twice a semester at the discretion of the evaluations director. If deemed necessary, the second intro process must begin within nine (9) days of the first process ending.
 \asubsubsubsection{The Introductory Packet}
 Each Introductory Process participant, after the first week, is given two (2) weeks to return a document that should contain a signature from all Active members, all Introductory Resident members, and ten (10) of any combination of the following:
 \begin{itemize}
@@ -545,7 +545,7 @@ Before the end of the Process, an Introductory Member is expected to:
 
 \asubsubsubsection{Introductory Evaluation}
 The Introductory Evaluation is the process by which House chooses which Introductory Members to extend an offer of full Resident or Non-Resident Membership.
-Occurs during the sixth week of each semester. If the evaluations director chooses to hold a second Introductory Process, the Introductory Evaluation will also occur during the twelfth week of each semester.
+Occurs at the conclusion of the final week of the Process.
 
 \asubsubsubsubsection{Voting}
 On a member by member basis, this evaluation process determines if each Introductory member has successfully completed the Introductory Process requirements \ref{Expectations of an Introductory Member}.


### PR DESCRIPTION
Check one:
- [X] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
These changes are a proposal to bring the introductory process timeline into the new system proposed throughout discussion this year. Instead of a ten week process, the process would now be six weeks long, and could occur twice in a semester. See https://discourse.csh.rit.edu/t/proposing-possible-changes-to-the-intro-process/130335/11 for further discussion on this topic.
