### PR TITLE
introduce requirements for active members to vote at introductory evaluations

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -552,8 +552,18 @@ Occurs at the conclusion of the final week of the Process.
 \asubsubsubsubsection{Voting}
 On a member by member basis, this evaluation process determines if each Introductory member has successfully completed the Introductory Process requirements \ref{Expectations of an Introductory Member}.
 A Simple Majority vote with a quorum of two-thirds of the Total Number of Possible Votes is required for the evaluation to be valid.
+In order for a Active Member to be counted as a Possible Vote they must meet the requirements outlined in \ref{Expectations of Voting Members}.
 Neither absentee nor proxy votes are allowed.
 House may choose any of the Outcomes for each member.
+\asubsubsubsubsection{Expectations of Voting Members}
+The following requirements must be met by the beginning of the Introductory Evaluation for an Active Member to be allowed to vote. Any of these requirements may be waived by the Evaluations Director or a simple majority vote by the Executive Board
+\begin{itemize}
+\item Attend all House meetings during the process
+\item Attend at least one House directorship meeting for each week of the process (including permanent and Ad Hoc directorship meetings)
+\item Attend at least one House social event during the process
+\item Attend at least two seminars relating to computing or electronics
+\end{itemize}
+
 \asubsubsubsubsection{Outcomes}
 \renewcommand{\theenumi}{\alph{enumi}} % For this section, we want items to use letters
 \begin{enumerate}

--- a/constitution.tex
+++ b/constitution.tex
@@ -552,11 +552,12 @@ Occurs at the conclusion of the final week of the Process.
 \asubsubsubsubsection{Voting}
 On a member by member basis, this evaluation process determines if each Introductory member has successfully completed the Introductory Process requirements \ref{Expectations of an Introductory Member}.
 A Simple Majority vote with a quorum of two-thirds of the Total Number of Possible Votes is required for the evaluation to be valid.
-In order for a Active Member to be counted as a Possible Vote they must meet the requirements outlined in \ref{Expectations of Voting Members}.
+In order for an Active Member to be counted as a Possible Vote they must meet the requirements outlined in \ref{Expectations of Voting Members}.
 Neither absentee nor proxy votes are allowed.
 House may choose any of the Outcomes for each member.
 \asubsubsubsubsection{Expectations of Voting Members}
-The following requirements must be met by the beginning of the Introductory Evaluation for an Active Member to be allowed to vote. Any of these requirements may be waived by the Evaluations Director or a simple majority vote by the Executive Board
+The following requirements must be met by the beginning of the Introductory Evaluation for an Active Member to be allowed to vote. 
+Any of these requirements may be waived by the Evaluations Director or a simple majority vote by the Executive Board
 \begin{itemize}
 \item Attend all House meetings during the process
 \item Attend at least one House directorship meeting for each week of the process (including permanent and Ad Hoc directorship meetings)


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
established requirements for active members to vote at introductory evaluations. Voting members must meet the same requirement that introductory members must meet with the exception of packet, all of these requirements can be waved by the Evaluations DIrector or eboard.
