### PR TITLE
Add git as a build dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/debian:bullseye AS builder
 
 RUN apt-get update -y && \
-    apt-get install -y texlive texlive-formats-extra make
+    apt-get install -y texlive texlive-formats-extra make git
 
 WORKDIR /build/
 


### PR DESCRIPTION
Check one:
- [ ] Semantic Change: something about the meaning of the text is different
- [x] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s): Oops I forgot to add git as a build-time dependency so the last updated field on the first page is blank