### PR TITLE
updated the constitution to reflect current spring evals process

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -209,8 +209,7 @@ Active Members receive the right to:
 Active Members currently on co-op forfeit their right to vote on house issues, and likewise do not count towards quorum.
 Exceptions may be made at the discretion of the Evaluations Director.
 \asubsection{Active Membership Evaluations}
-Active Members are evaluated semi-annually through the Evaluation Process as described in \ref{Evaluations Processes}.
-Failure of the Evaluation Process could result in the member being asked to find alternative housing as soon as possible in accordance with all applicable Residence Life policies regarding room changes.
+Active Members are evaluated annually through the Evaluation Process as described in \ref{Evaluations Processes}.
 \asubsection{Active Membership Leave of Absence}
 An Active member may at any time request a leave of absence using the process described in \ref{Leave of Absence}.
 For the duration of an absence, a member:


### PR DESCRIPTION

Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
removed the line that stated membership evaluations where bi-annual
removed the line that said we would kick failed members off floor
