### PR TITLE
Clarify Election Qualification Overrides

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -771,7 +771,7 @@ The following process is used for making changes to the Code of Conduct document
 \end{enumerate}
 
 \asubsection{Overriding Directorships Qualifications}
-Qualifications pertaining to a specific directorship election can be overriding via a Constitutional Override, as explained in \ref{Semantic Changes}. Overrides will apply to a specific qualification of the directorship, and if passed, to all candidates for said directorship.
+When executing a Constitutional Override \ref{Semantic Changes} for a Qualification specified in \ref{Qualifications}, the Override shall apply to a specific qualification of the directorship, and if passed, to all candidates for said directorship.
 
 \asection{Selection}
 \asubsection{Dual Directorship}
@@ -985,4 +985,3 @@ The Judicial Board will be responsible for making all necessary inquiries into t
 The Judicial Board may present an official ruling following the Judicial Investigation.
 This ruling may be appealed in the same manner as an Executive Board decision \ref{Appeals}.
 \end{document}
-

--- a/constitution.tex
+++ b/constitution.tex
@@ -770,6 +770,9 @@ The following process is used for making changes to the Code of Conduct document
 \item Candidates must be Active Members
 \end{enumerate}
 
+\asubsection{Overriding Directorships Qualifications}
+Qualifications pertaining to a specific directorship election can be overriding via a Constitutional Override, as explained in \ref{Semantic Changes}. Overrides will apply to a specific qualification of the directorship, and if passed, to all candidates for said directorship.
+
 \asection{Selection}
 \asubsection{Dual Directorship}
 Social and Research and Development are the only voting Executive Board positions that allow for Dual Directorship.
@@ -982,3 +985,4 @@ The Judicial Board will be responsible for making all necessary inquiries into t
 The Judicial Board may present an official ruling following the Judicial Investigation.
 This ruling may be appealed in the same manner as an Executive Board decision \ref{Appeals}.
 \end{document}
+

--- a/constitution.tex
+++ b/constitution.tex
@@ -10,6 +10,7 @@
 \usepackage{hyperref}
 % Reformat section titles
 \usepackage{titlesec}
+\usepackage{cleveref}
 
 % This package is useful for debugging label problems
 % Comment out in final revision
@@ -770,8 +771,11 @@ The following process is used for making changes to the Code of Conduct document
 \item Candidates must be Active Members
 \end{enumerate}
 
-\asubsection{Overriding Directorships Qualifications}
-When executing a Constitutional Override \ref{Semantic Changes} for a Qualification specified in \ref{Qualifications}, the Override shall apply to a specific qualification of the directorship, and if passed, to all candidates for said directorship.
+\asubsection{Guidelines on Overriding Executive Board Qualifications}
+\begin{itemize}
+\item This section provides no definitions, instead serving to clarify the applicability of Overrides to Qualifications in the Selection of members of the Executive Board.
+\item When executing a Constitutional Override \ref{Semantic Changes} for a Qualification specified in sections {\crefname{Qualifications}{}{}\crefrange{Qualifications to be the Chairperson, Evaluations Director}{Qualifications to be the House Secretary or an Ad Hoc Director}}, the Override shall apply to a specific qualification of the directorship, and if passed, to all candidates for said directorship.
+\end{itemize}
 
 \asection{Selection}
 \asubsection{Dual Directorship}


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Add clarification to how qualifications for an EBoard candidate are
overriden via Constitutional Override.
