### PR TITLE
constitution: add a process for waiving candidacy requirements

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -770,6 +770,16 @@ The following process is used for making changes to the Code of Conduct document
 \item Candidates must be Active Members
 \end{enumerate}
 
+\asubsection{Waiving of Requirements}
+\begin{enumerate}
+  \item The following requirements may be waived as decided by a Two-Thirds Immediate Vote as described in \ref{Two-Thirds} and \ref{Immediate Vote}:
+    \begin{enumerate}
+      \item Candidates must have at least one full semester of House membership as an Active Member
+      \item Candidates must reside on floor during the term of office
+    \end{enumerate}
+  \item This process waives the enumerated requirements for a given election for all candidates on a per-directorship basis
+\end{enumerate}
+
 \asection{Selection}
 \asubsection{Dual Directorship}
 Social and Research and Development are the only voting Executive Board positions that allow for Dual Directorship.


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

In the past, overrides have been used to accomplish this. We keep not having quorum for overrides and that makes me sad. Additionally, the lack of a codified process left a lot of undesired flexibility here. I would be open to changing the percentage of votes needed to something a bit higher (Perhaps more in the neighborhood of 75%?)