### PR TITLE
Add Active Member Requirement for Elections

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -795,7 +795,7 @@ The following special cases cover the operation of a dual directorship:
 		Each candidate is given a minimum of twenty-four hour period to accept or decline the nomination.
 		A list of all nominees who have accepted their nominations will be posted shortly thereafter.
 	\item The date and time of the candidate(s)'s speeches will be announced by a member of the Executive Board at least five (5) days prior to the event. 
-		All Active Members are expected to attend candidate speeches as specified in \ref{Expectations of House Members}.
+		All Active Members are expected to attend candidate speeches in accordance with \ref{Expectations of House Members}.
 		If a member cannot attend due to a scheduling conflict, they may provide a reason for their absence to the Evaluations Director, who will record the reason with the absence.
 	\item Each candidate will be given an equal amount of time before the House to present their platform of candidacy.
 	\item Ballots will then be distributed and voting will be open for a minimum of a forty-eight hour period.

--- a/constitution.tex
+++ b/constitution.tex
@@ -796,7 +796,7 @@ The following special cases cover the operation of a dual directorship:
 		A list of all nominees who have accepted their nominations will be posted shortly thereafter.
 	\item The date and time of the candidate(s)'s speeches will be announced by a member of the Executive Board at least five (5) days prior to the event. 
 		All Active Members are expected to attend candidate speeches as specified in \ref{Expectations of House Members}.
-		If a member cannot attend due to a scheduling conflict, they may provide a reason for their absence to the Evaluations Director, who will note is as an Absence with Reason.
+		If a member cannot attend due to a scheduling conflict, they may provide a reason for their absence to the Evaluations Director, who will record the reason with the absence.
 	\item Each candidate will be given an equal amount of time before the House to present their platform of candidacy.
 	\item Ballots will then be distributed and voting will be open for a minimum of a forty-eight hour period.
 		The Ballots will list, in random order, all of the candidates who are qualified for a given office with a means to indicate the selection of one of the candidates.

--- a/constitution.tex
+++ b/constitution.tex
@@ -794,7 +794,7 @@ The following special cases cover the operation of a dual directorship:
 	\item The candidates will be notified of their nomination.
 		Each candidate is given a minimum of twenty-four hour period to accept or decline the nomination.
 		A list of all nominees who have accepted their nominations will be posted shortly thereafter.
-	\item The date and time of the candidate(s)'s speeches will be announced by a member of the Executive Board at least five (5) days prior to the event. 
+	\item The date and time of candidate speeches will be announced by a member of the Executive Board at least five (5) days prior to the event. 
 		All Active Members are expected to attend candidate speeches in accordance with \ref{Expectations of House Members}.
 		If a member cannot attend due to a scheduling conflict, they may provide a reason for their absence to the Evaluations Director, who will record the reason with the absence.
 	\item Each candidate will be given an equal amount of time before the House to present their platform of candidacy.

--- a/constitution.tex
+++ b/constitution.tex
@@ -655,7 +655,7 @@ If a member disagrees with the outcome of any evaluation, (e.g. is not asked to 
 If the member is still unsatisfied after being heard by the Executive Board, the appeal may be brought to the attention of the ResLife Advisor.
 
 \asubsubsection{Expectations of House Members}
-Each member is required to pay House dues as stated in \ref{Collection of House Dues}, attend all House Meetings, and attend at least fifteen (15) of the House directorship meetings (including permanent and Ad Hoc directorship meetings) for each Academic Semester in which they are an Active Member.
+Each member is required to pay House dues as stated in \ref{Collection of House Dues}, attend all House Meetings and Elections, and attend at least fifteen (15) of the House directorship meetings (including permanent and Ad Hoc directorship meetings) for each Academic Semester in which they are an Active Member.
 \\* \\*
 The member must participate significantly in at least one major project during the academic year.
 The member is required to submit a description for this major project to the Executive Board for approval.
@@ -794,7 +794,9 @@ The following special cases cover the operation of a dual directorship:
 	\item The candidates will be notified of their nomination.
 		Each candidate is given a minimum of twenty-four hour period to accept or decline the nomination.
 		A list of all nominees who have accepted their nominations will be posted shortly thereafter.
-	\item The date and time of the candidate(s)'s speeches will be announced by a member of the Executive Board at least five (5) days prior to the event. This will be treated as a House Meeting, with the expectation that all Active Members will attend and attendance will be taken. If the speeches take place at a traditional House Meeting, only one attendance will be taken.
+	\item The date and time of the candidate(s)'s speeches will be announced by a member of the Executive Board at least five (5) days prior to the event. 
+		All Active Members are expected to attend this Election, as specified in \ref{Expectations of House Members}.
+		Exemptions to attendance may be given at the discretion of the Evaluations Director.
 	\item Each candidate will be given an equal amount of time before the House to present their platform of candidacy.
 	\item Ballots will then be distributed and voting will be open for a minimum of a forty-eight hour period.
 		The Ballots will list, in random order, all of the candidates who are qualified for a given office with a means to indicate the selection of one of the candidates.
@@ -983,4 +985,3 @@ The Judicial Board will be responsible for making all necessary inquiries into t
 The Judicial Board may present an official ruling following the Judicial Investigation.
 This ruling may be appealed in the same manner as an Executive Board decision \ref{Appeals}.
 \end{document}
-

--- a/constitution.tex
+++ b/constitution.tex
@@ -655,7 +655,7 @@ If a member disagrees with the outcome of any evaluation, (e.g. is not asked to 
 If the member is still unsatisfied after being heard by the Executive Board, the appeal may be brought to the attention of the ResLife Advisor.
 
 \asubsubsection{Expectations of House Members}
-Each member is required to pay House dues as stated in \ref{Collection of House Dues}, attend all House Meetings and Elections, and attend at least fifteen (15) of the House directorship meetings (including permanent and Ad Hoc directorship meetings) for each Academic Semester in which they are an Active Member.
+Each member is required to pay House dues as stated in \ref{Collection of House Dues}, attend all House Meetings and Executive Board candidate speeches, and attend at least fifteen (15) of the House directorship meetings (including permanent and Ad Hoc directorship meetings) for each Academic Semester in which they are an Active Member.
 \\* \\*
 The member must participate significantly in at least one major project during the academic year.
 The member is required to submit a description for this major project to the Executive Board for approval.
@@ -795,8 +795,8 @@ The following special cases cover the operation of a dual directorship:
 		Each candidate is given a minimum of twenty-four hour period to accept or decline the nomination.
 		A list of all nominees who have accepted their nominations will be posted shortly thereafter.
 	\item The date and time of the candidate(s)'s speeches will be announced by a member of the Executive Board at least five (5) days prior to the event. 
-		All Active Members are expected to attend this Election, as specified in \ref{Expectations of House Members}.
-		Exemptions to attendance may be given at the discretion of the Evaluations Director.
+		All Active Members are expected to attend candidate speeches as specified in \ref{Expectations of House Members}.
+		If a member cannot attend due to a scheduling conflict, they may provide a reason for their absence to the Evaluations Director, who will note is as an Absence with Reason.
 	\item Each candidate will be given an equal amount of time before the House to present their platform of candidacy.
 	\item Ballots will then be distributed and voting will be open for a minimum of a forty-eight hour period.
 		The Ballots will list, in random order, all of the candidates who are qualified for a given office with a means to indicate the selection of one of the candidates.

--- a/constitution.tex
+++ b/constitution.tex
@@ -794,6 +794,7 @@ The following special cases cover the operation of a dual directorship:
 	\item The candidates will be notified of their nomination.
 		Each candidate is given a minimum of twenty-four hour period to accept or decline the nomination.
 		A list of all nominees who have accepted their nominations will be posted shortly thereafter.
+	\item The date and time of the candidate(s)'s speeches will be announced by a member of the Executive Board at least five (5) days prior to the event. This will be treated as a House Meeting, with the expectation that all Active Members will attend and attendance will be taken. If the speeches take place at a traditional House Meeting, only one attendance will be taken.
 	\item Each candidate will be given an equal amount of time before the House to present their platform of candidacy.
 	\item Ballots will then be distributed and voting will be open for a minimum of a forty-eight hour period.
 		The Ballots will list, in random order, all of the candidates who are qualified for a given office with a means to indicate the selection of one of the candidates.
@@ -982,3 +983,4 @@ The Judicial Board will be responsible for making all necessary inquiries into t
 The Judicial Board may present an official ruling following the Judicial Investigation.
 This ruling may be appealed in the same manner as an Executive Board decision \ref{Appeals}.
 \end{document}
+


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

Requires Active Members to attend Elections with sufficient notice. Attendance will be taken in the same manner as a House Meeting, with a 5 day notice required by E-Board. 