### PR TITLE
Reform Alumni in bad standing votes

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -190,8 +190,8 @@ Active Membership is open to all students currently enrolled at the Rochester In
 \asubsection{Active Membership Selection}
 Qualifying members may self-select into Active Membership by paying dues to the Financial Director and notifying the Evaluations Director.
 \\*\\*
-Any Alumni Member in bad standing (\ref{Alumni Membership Selection}) may become an Active Member by notifying the Evaluations Director of their intent to participate, who will bring them up for vote at the next House meeting.
-If Fifty Percent of Active Members present are in favor of the return (as defined in \ref{Fifty Percent}), the Alumni is reinstated as an Active Member with Off-Floor status effective immediately.
+Any Alumni Member in bad standing (\ref{Alumni Membership Selection}) may become an Active Member by notifying the Evaluations Director of their intent to participate, who will bring them up for a Simple Majority vote at the next House meeting.
+If the vote passes the Alumni is reinstated as an Active Member with Off-Floor status effective immediately.
 \asubsection{Active Membership Expectations}
 Active members are expected to be active participants in the House as defined in \ref{Expectations of House Members}.
 \asubsection{Active Membership Privileges}

--- a/constitution.tex
+++ b/constitution.tex
@@ -190,9 +190,8 @@ Active Membership is open to all students currently enrolled at the Rochester In
 \asubsection{Active Membership Selection}
 Qualifying members may self-select into Active Membership by paying dues to the Financial Director and notifying the Evaluations Director.
 \\*\\*
-Any Alumni Member in bad standing (\ref{Alumni Membership Selection}) may become an Active Member by notifying the Evaluations Director of their intent to participate, who will bring them up for vote at the next Evaluations meeting.
-If a majority is in favor of the return, the Alumni is reinstated as an Active Member with Off-Floor status effective immediately.
-The decision will be announced at the following House meeting.
+Any Alumni Member in bad standing (\ref{Alumni Membership Selection}) may become an Active Member by notifying the Evaluations Director of their intent to participate, who will bring them up for vote at the next House meeting.
+If Fifty Percent of Active Members present are in favor of the return (as defined in \ref{Fifty Percent}), the Alumni is reinstated as an Active Member with Off-Floor status effective immediately.
 \asubsection{Active Membership Expectations}
 Active members are expected to be active participants in the House as defined in \ref{Expectations of House Members}.
 \asubsection{Active Membership Privileges}


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
changes Bad Standing votes so that they are held during House Meeting
