### PR TITLE
Clarifies the voting members must be Eboard

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -342,7 +342,7 @@ Any large expenditures or large effect decisions must be brought before the enti
 \asection{Closed Executive Board}
 Closed Executive Board Meetings are open only to the Chairperson, Voting Members of the Executive Board, and those with the express permission of the Executive Board.
 A closed Executive Board meeting may be called at any time by any member of the Executive Board.
-However, the Chairperson and at least two-thirds of the Voting Members must be present for the meeting to be called.
+However, the Chairperson and at least two-thirds of the Voting Members of the Executive Board must be present for the meeting to be called.
 
 \asection{Responsibilities}
 \renewcommand{\theenumi}{\alph{enumi}} % For this section, we want items to use letters


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Made it clear that only a majority of voting Eboard members must be present.
