### PR TITLE
Change alumni in bad standing vote to align with recent practice

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -190,7 +190,6 @@ Active Membership is open to all students currently enrolled at the Rochester In
 \asubsection{Active Membership Selection}
 Qualifying members may self-select into Active Membership by paying dues to the Financial Director and notifying the Evaluations Director.
 \\*\\*
-Any Alumni Member in bad standing (\ref{Alumni Membership Selection}) may become an Active Member by notifying the Evaluations Director of their intent to participate, who will bring them up for a Simple Majority vote at the next House meeting.
 If the vote passes the Alumni is reinstated as an Active Member with Off-Floor status effective immediately.
 \asubsection{Active Membership Expectations}
 Active members are expected to be active participants in the House as defined in \ref{Expectations of House Members}.
@@ -232,6 +231,7 @@ Active members who depart house (i.e. resign) after passing the current operatin
 \\*\\*
 Active members who depart house without passing the current operating session's Membership Evaluations are considered to be Alumni in bad standing.
 This may be appealed to the Executive Board in order to pursue a different outcome.
+Any Alumni Member in bad standing may become an Alumni in good standing by notifying the Evaluations Director of their intent to be brought up for a vote, who will bring them up for a Simple Majority vote at the next House meeting.
 \asubsection{Alumni Membership Expectations}
 There are no expectations associated with the Alumni Membership status.
 \asubsection{Alumni Membership Privileges}


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

Recent practice of the organization has been to vote alumni in bad standing into good standing rather than directly into active membership. This brings the constitution up to date with current practices. 