### PR TITLE
Removes ability for RTP's to override requirements

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -724,8 +724,6 @@ Membership is composed of all Root Type Persons.
 \renewcommand{\theenumi}{\alph{enumi}} % For this section, we want items to use letters
 \begin{enumerate}
 	\item Candidates must have been an On-Floor Active Member in good standing within the last twelve months, or been an Off-Floor Active Member and have lived on the floor within the last twelve months.
-	\item Candidates may be granted an exemption by current Root Type Persons.
-		Such an exemption may be withdrawn at any time by the current Root Type Persons.
 	\item Prior Root Type Persons are those members who are no longer current Active Members and have not been granted an extension by the current Root Type Persons.
 		Prior Root Type Persons are not guaranteed access to the current root passwords and other authentication tokens.
 	\item The current Root Type Persons may from time to time draft rules and regulations specifying the rights and privileges of Prior Root Type Persons.


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
removing the ability for RTP's to override the requirements outlined in the constitution to elect a new RTP. Would require a constitutional override instead if an ineligible RTP was to be elected.
