### PR TITLE
Removed line stating that failed intro members had to move off floor in section 5.D.2.A.4.C

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -581,7 +581,6 @@ Any of these requirements may be waived by the Evaluations Director or a simple 
 \begin{enumerate}
 	\item Introductory Members may be offered Active Membership (\ref{Active Membership}) provided they meet the requirements described in \ref{Expectations of an Introductory Member}, at the discretion of House.
 	\item If an Introductory Member fails to meet the requirements, their membership will be revoked.
-		In addition, the participant is asked to find alternative housing as soon as possible in accordance with all applicable Residence Life policies regarding room changes.
 	\item An Introductory member may be given a conditional to complete as a means of making up for missing requirements.
 		A conditional may be proposed by any member present at the Introductory Evaluation and, if it is approved by the Evaluations Director, is then voted on by House.
 		Each conditional consists of a set of additional requirements and a deadline for completing them.


### PR DESCRIPTION
…in section 5.D.2.A.4.C

Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Removed line that says that intro members that fail intro evals need to move off floor so that it matches current practice
