### PR TITLE
table of contents numbers now start at correct page number

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -66,6 +66,7 @@
 \maketitle
 
 \tableofcontents
+\setcounter{page}{4}
 
 % ARTICLE I - ABBREVIATIONS
 \article{Abbreviations and Definitions}


### PR DESCRIPTION
Check one:
- [ ] Semantic Change: something about the meaning of the text is different
- [X] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

table of contents numbers are correct now