### PR TITLE
prevent multiple simultaneous memberships

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -151,7 +151,7 @@ When describing membership types, the following terms are used:
 \asection{Introductory Membership}
 
 \asubsection{Introductory Membership Qualifications}
-Intro Membership is open to all students currently enrolled at RIT.
+Intro Membership is open to all students currently enrolled at RIT, excluding all Active and Alumni Members.
 
 \asubsection{Introductory Membership Selection}
 Applicants notify the Evals Director of their interest in membership by submitting an application.


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

This change prevents current active and alumni members from reentering the introductory process, thereby preventing an opportunity for constitutional ambiguity.
