### PR TITLE
Allow off floor intro members to sign packets

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -197,7 +197,7 @@ If deemed necessary by the Evals Director or by an E-Board Vote, the second Intr
 If a second Intro Process is approved, the Evals Director may initiate a new Intro Packet within the first or second week of the process.
 
 \asubsubsection{The Introductory Packet}
-Each Intro Process participant, after the first week, is given two weeks to obtain signatures from all Active Members who have passed a Membership Eval, all On-Floor Intro and Active Members, and ten of any combination of Alumni, Honorary, and Advisory Members.
+Each Intro Process participant, after the first week, is given two weeks to obtain signatures from all Active and Intro Members, and ten of any combination of Alumni, Honorary, and Advisory Members.
 At the discretion of the Evals Director or as the result of an E-Board Vote, any Intro Packet may be extended to accommodate extenuating circumstances.
 
 \asubsubsection{Expectations of an Introductory Member}


### PR DESCRIPTION
Check one:
- [X] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Allow off floor intro members to sign packets.

Also fixes wording about which active members are expected to sign packets in order to make it simpler and clearer
