### PR TITLE
clarify active member resignations

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -335,7 +335,7 @@ For the duration of an absence, a member:
 
 \asubsection{Active Membership Resignations}
 An Active Member may resign by submitting, in writing, the reason for resignation to the Chair or the Evals Director.
-Instead of forfeiting membership, Active Members who resign may elect to become Alumni as described in \ref{Alumni Membership Selection}.
+Instead of forfeiting membership, Active Members who meet the requirements outlined in \ref{Alumni Membership Qualifications} who resign may elect to become Alumni as described in \ref{Alumni Membership Selection}.
 The resignation will take effect immediately and an announcement will be made at the following House Meeting.
 
 \asubsection{Active Membership Term}


### PR DESCRIPTION
Check one:
- [ ] Semantic Change: something about the meaning of the text is different
- [x] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Clarify that active members can only resign into alumni membership after passing a membership evaluation.

