### PR TITLE
remove the social event requirement from gatekeep

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -283,7 +283,6 @@ Any of these requirements may be waived by the Evals Director or an E-Board Vote
 \begin{enumerate}
 	\item Attend all House Meetings during the Intro Process
 	\item Attend at least one directorship meeting for each week of the Intro Process % The number of directorship meetings intended here is equal to the number of the weeks in the process, not just one each week
-	\item Attend at least one CSH social event during the Intro Process
 	\item Attend at least two Technical Seminars during the Intro Process
 \end{enumerate}
 


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Remove the social event requirement for upperclassmen. This isn't tracked, so this change would bring the constitution up to date with current practice.

