### PR TITLE
clarify voting members

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -254,7 +254,7 @@ If the vote passes, the Alumni is reinstated as an Active Member with Off-Floor 
 
 \asubsection{Active Membership Expectations}
 Active Members are expected to be active participants in CSH as defined in \ref{Expectations of Active Members}.
-Active Voting Members are expected to meet the requirements defined in \ref{Expectations of Voting Members}.
+Active Voting Members are eligible to become Voting Members according to the requirements defined in \ref{Qualifications of Voting Members}.
 
 \asubsubsection{Expectations of Active Members}
 Active Members are required to pay dues as stated in \ref{Collection of Dues}, attend all House Meetings and E-Board candidate speeches, and attend at least fifteen of the directorship meetings for each semester in which they are an Active Member.
@@ -275,10 +275,10 @@ Active Members receive the privilege to:
 	\item Receive priority for on-floor housing, or apply for On-Floor Status
 \end{enumerate}
 
-\asubsubsection{Expectations of Voting Members}
+\asubsubsection{Qualifications of Voting Members}
 \renewcommand{\theenumi}{\arabic{enumi}} % For this section, we want items to use letters
 
-The following requirements must be met by the beginning of the Intro Eval for an Active Member to be allowed to vote.
+For an Active Member to be allowed to vote in an Intro Eval, they must meet the following requirements by the beginning of the Intro Eval.
 Any of these requirements may be waived by the Evals Director or an E-Board Vote.
 \begin{enumerate}
 	\item Attend all House Meetings during the Intro Process
@@ -286,6 +286,9 @@ Any of these requirements may be waived by the Evals Director or an E-Board Vote
 	\item Attend at least one CSH social event during the Intro Process
 	\item Attend at least two Technical Seminars during the Intro Process
 \end{enumerate}
+
+\asubsubsection{Expectations of Voting Members}
+Voting Members are expected to attend and vote at the Intro Eval for which they have qualified. If they cannot attend the Intro Eval, they are expected to notify the Evals Director before the Intro Eval.
 
 \asubsection{Active Membership Evaluations}
 Active Members are evaluated annually through the Eval Process described below.


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Change the current Expectations of Voting Members section to be the Qualifications section, and add the expectation that voting members vote at six weeks.
Also add a clause that allows voting members to opt out of six weeks, thus lowering quorum.

