### PR TITLE
add explicit mechanisms for housing priority / access

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -881,10 +881,11 @@ They still have access to all other privileges associated with their membership,
 The Housing Priority System is a means for determining the priority a member has in a housing issue or the assignment of available housing.
 The member with top priority is the member with On-Floor Status and the most Housing Priority Points.
 Housing Priority Points are accumulated once per Operating Session at the conclusion of the Membership Eval.
-Each Active Member who passes the Membership Eval is granted two Housing Priority Points.
+Each Active Member who passes the Membership Eval is granted two Housing Priority Points. 
 Members registered with NTID receive priority over members with equivalent Housing Priority points. % NTID students can ONLY choose dorms with doorbells, so this helps ensure that students who need these rooms have access to them. 
 Members who require accommodations may be temporarily granted additional Housing Priority Points at the request of RIT Housing or at the discretion of the Evaluations Director. 
 Temporary Housing Priority Points remain in effect until the end of the Standard Operating Session or an earlier date, as specified when granted.
+Additionally, members are granted 0.5 Temporary Housing Priority Points for the duration of time that they are assigned to the room they currently live in. 
 
 \asection{Evaluations Processes}
 At the beginning of any Eval Process, the Evals Director must read the sections of the CSH Constitution regarding the relevant Eval Process.

--- a/constitution.tex
+++ b/constitution.tex
@@ -882,6 +882,9 @@ The Housing Priority System is a means for determining the priority a member has
 The member with top priority is the member with On-Floor Status and the most Housing Priority Points.
 Housing Priority Points are accumulated once per Operating Session at the conclusion of the Membership Eval.
 Each Active Member who passes the Membership Eval is granted two Housing Priority Points.
+Members registered with NTID receive priority over members with equivalent Housing Priority points. % NTID students can ONLY choose dorms with doorbells, so this helps ensure that students who need these rooms have access to them. 
+Members who require accommodations may be temporarily granted additional Housing Priority Points at the request of RIT Housing or at the discretion of the Evaluations Director. 
+Temporary Housing Priority Points remain in effect until the end of the Standard Operating Session or an earlier date, as specified when granted.
 
 \asection{Evaluations Processes}
 At the beginning of any Eval Process, the Evals Director must read the sections of the CSH Constitution regarding the relevant Eval Process.


### PR DESCRIPTION
Check one:
- [X] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

NTID students can only select dorms with doorbells, so this amendment gives tiebreaking priority to NTID students to help ensure they have equal access to rooms in CSH.

The amendment adds additional explicit mechanisms for housing priority to ensure equal access to housing. To the best of my knowledge, these are mostly in accordance with recent practice, with the exception of making them additionally available at the discretion of the Evaluations director.