### PR TITLE
Different section for Amendments and Overrides

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -125,12 +125,14 @@ A Maintainer may approve any proposed change that does not affect the meaning of
 Alternatively, the change may be presented at a House Meeting for discussion followed by an Immediate One-Half Vote with fifty percent quorum.
 
 \asubsection{Semantic Changes}
+\asubsubsection{Amendments}
 Any semantic change to the Constitution requires the change to be proposed in writing for discussion at a House Meeting.
 Any modifications made due to the discussion are added to the written proposal and the modified proposal is posted during the week.
 The final proposal is presented the following week, and ballots are distributed for a Balloted Two-Thirds Vote with two-thirds quorum as described in \ref{Balloted Vote}.
 The ballots are collected for a minimum of a forty-eight hour period.
 A quorum of two-thirds of Eligible Votes must cast ballots for the vote to be official.
 A vote equaling or exceeding two-thirds of the number of Votes Cast is required for the change to be placed into the Constitution.
+\asubsubsection{Overrides}
 The Constitution may be overridden by an Immediate Nine-Tenths Vote with eighty-five percent quorum as described in \ref{Immediate Vote}.
 
 % ARTICLE IV - MEMBERSHIP


### PR DESCRIPTION
Check one:
- [ ] Semantic Change: something about the meaning of the text is different
- [x] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Gave amendments and overrides their own sections in the semantic changes section. 