### PR TITLE
Resolve #238 Advisory Members' Qualifications Are Never Reevaluated

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -375,7 +375,7 @@ Alumni Membership shall last indefinitely or until the member chooses to pursue 
 Honorary Membership is open to a person whom CSH feels has contributed great personal effort to CSH and is deserving of recognition.
 
 \asubsection{Advisory Membership Qualifications}
-Advisory Membership is open to all members of the RIT professional, academic, or administrative staff.
+Advisory Membership is open to all current members of the RIT professional, academic, or administrative staff.
 
 \asubsection{Honorary and Advisory Membership Selection}
 \begin{enumerate}
@@ -401,8 +401,11 @@ Honorary and Advisory Members are not subject to any Evals.
 An Honorary or Advisory Member may resign by submitting in writing the reason for resignation to the Chair.
 The resignation will be read at the following House Meeting and become effective at that time.
 
-\asubsection{Honorary and Advisory Membership Term}
-Honorary and Advisory Memberships shall last until the member resigns.
+\asubsection{Honorary Membership Term}
+Honorary Membership shall last until the member resigns.
+
+\asubsection{Advisory Membership Term}
+Advisory Membership shall last until the member resigns or is no longer employed by RIT, whichever comes first.
 
 \asection{Leave of Absence}
 A leave of absence offers the option for members to take extended time away from their responsibilities to House for any number of personal issues including, but not limited to, physical illness, mental illness, or care giving for a sick family member.


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Clarified that advisory membership is open to current RIT staff.
Also split honorary and advisory membership term subsections and added automatic termination of advisory membership once they stop working at RIT.