### PR TITLE
Resolve #248 Oops, Members on Co-Op Can't Skip Meetings & Do Count Towards Quorum

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -901,7 +901,7 @@ This section outlines the different types of votes and ballots used to make deci
 \asection{Definitions}
 
 \asubsection{Eligible Votes}
-The number of Active Members eligible to vote on the issue (e.g., not on co-op).
+The number of Active Members eligible to vote on the issue.
 
 \asubsection{Votes Cast}
 The number of ballots cast in a vote, excluding abstentions.


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Re-added previously removed language clarifying the privileges of members on co-op.
Also restored clarification to the definition of Eligible Votes.