### PR TITLE
RTP Changes - Copyright Grant Hawerlander

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -767,14 +767,14 @@ Giving an extension to a previous Active Member is the same as starting a select
 Candidates must be Active Members or previous Active Members who are given an extension by the RTPs.
 
 \asubsubsection{Prior Root Type Persons}
-Prior RTPs are any members who were previously an RTP and are not currently on an extension given by the RTPs.
+Prior RTPs are any members who were previously an RTP and are not currently an Active Member or on an extension given by the RTPs.
 Prior RTPs are not guaranteed access to any elevated permissions to any systems or networks, including but not limited to the RTP LDAP role, Vault, or the root password.
 The current RTPs may draft rules and regulations specifying the rights and privileges of Prior RTPs.
 
 \asubsubsection{Renewal of a Root Type Person}
-At the conclusion of each standard operating session, every RTP desiring to maintain their active status for the upcoming academic year must participate in a renewal process. 
+At the conclusion of each standard operating session, those intending to keep the rights and responsibilities of a current RTP must participate in a renewal process. 
 During the second to last E-Board Meeting of the semester, the OpComm Director shall present a formal statement summarizing the contributions and performance of each RTP. 
-After each statement, an E-Board Vote, as described in \ref{Executive Board Vote} will be conducted to determine each candidate's continuation. 
+After each statement, an E-Board Vote, as described in \ref{Executive Board Vote}, will be conducted to determine each candidate's continuation. 
 Failure to secure the required majority vote will result in the RTP being required to resign their position.
 
 \asubsubsection{Creation of Accounts}

--- a/constitution.tex
+++ b/constitution.tex
@@ -772,10 +772,10 @@ Prior RTPs are not guaranteed access to any elevated permissions to any systems 
 The current RTPs may draft rules and regulations specifying the rights and privileges of Prior RTPs.
 
 \asubsubsection{Renewal of a Root Type Person}
-At the conclusion of each academic year, every RTP desiring to maintain their active status for the upcoming academic year must participate in a renewal process. 
-During the second to last E-Board Meeting of the semester, the Operational Communications Director shall present a formal statement summarizing the contributions and performance of each RTP. 
-After each statement, an E-Board Vote will be conducted to determine each candidate's continuation. 
-If the vote does not pass, that member will become a Prior RTP.
+At the conclusion of each standard operating session, every RTP desiring to maintain their active status for the upcoming academic year must participate in a renewal process. 
+During the second to last E-Board Meeting of the semester, the OpComm Director shall present a formal statement summarizing the contributions and performance of each RTP. 
+After each statement, an E-Board Vote, as described in \ref{Executive Board Vote} will be conducted to determine each candidate's continuation. 
+Failure to secure the required majority vote will result in the RTP being required to resign their position.
 
 \asubsubsection{Creation of Accounts}
 RTPs have the authority to manage user accounts for CSH systems.

--- a/constitution.tex
+++ b/constitution.tex
@@ -745,7 +745,7 @@ E-Board may choose to approve or reject the nomination by E-Board Vote with a qu
 
 \asection{Root Type Persons}
 The OpComm Directorship is responsible for overseeing the implementation of maintenance and upgrades to the CSH computer systems networks.
-It is a self-governing committee making decisions by Immediate Relative Majority vote with two-thirds quorum of current RTPs.
+It is a committee making decisions by Immediate Relative Majority vote with two-thirds quorum of current RTPs.
 Membership is composed of all RTPs.
 
 \asubsection{Selection of a Root Type Person}
@@ -766,6 +766,12 @@ Candidates must be Active Members.
 Prior RTPs are those members who are no longer current Active Members and have not been granted an extension by the current RTPs.
 Prior RTPs are not guaranteed access to the current root passwords and other authentication tokens.
 The current RTPs may draft rules and regulations specifying the rights and privileges of Prior RTPs.
+
+\asubsubsection{Renewal of a Root Type Person}
+At the conclusion of each academic year, every RTP desiring to maintain their active status for the upcoming academic year must participate in a renewal process. 
+Prior to the vote, the Operational Communications Director shall present a formal statement summarizing each RTP’s contributions and performance. 
+Subsequently, E-Board will conduct an Immediate Relative Majority Vote on each candidate's continuation. 
+RTPs failing to secure the required majority will be mandated to resign their RTP status.
 
 \asubsubsection{Creation of Accounts}
 RTPs have the authority to manage user accounts for CSH systems.

--- a/constitution.tex
+++ b/constitution.tex
@@ -744,8 +744,11 @@ Any member may nominate a qualified member for Maintainer status to E-Board for 
 E-Board may choose to approve or reject the nomination by E-Board Vote with a quorum of seventy-five percent of the Eligible Votes.
 
 \asection{Root Type Persons}
-The OpComm Directorship is responsible for overseeing the implementation of maintenance and upgrades to the CSH computer systems networks.
-It is a committee making decisions by Immediate Relative Majority vote with two-thirds quorum of current RTPs.
+Root Type Persons are the members that make up the OpComm Directorship. 
+They are responsible for overseeing the implementation of maintenance and upgrades to the CSH computer systems and networks. 
+
+\asubsection{OpComm Directorship}
+The OpComm Directorship is a committee making decisions by Immediate Relative Majority vote with two-thirds quorum of current RTPs.
 Membership is composed of all RTPs.
 
 \asubsection{Selection of a Root Type Person}
@@ -755,31 +758,32 @@ Membership is composed of all RTPs.
 	\item Each candidate is given a minimum of twenty-four hour period to accept or decline the nomination.
 	\item A list of all nominees who have accepted is presented to E-Board for approval.
 	      This E-Board Meeting is closed to E-Board Members, RTPs, and members with explicit invitation from E-Board.
-	\item If an E-Board Member is a candidate for the office in discussion, the member is absent and their vote is abstained.
+	\item If an E-Board Member is a candidate for the office in discussion, the member is absent, and their vote is abstained.
 	      An E-Board Vote, as described in \ref{Executive Board Vote}, is taken to determine whether the nominations of the RTP(s) are accepted.
 \end{enumerate}
+Giving an extension to a previous Active Member is the same as starting a selection process for a new RTP and should also follow this process.
 
 \asubsubsection{Qualifications of a Root Type Person}
-Candidates must be Active Members.
+Candidates must be Active Members or previous Active Members who are given an extension by the RTPs.
 
 \asubsubsection{Prior Root Type Persons}
-Prior RTPs are those members who are no longer current Active Members and have not been granted an extension by the current RTPs.
-Prior RTPs are not guaranteed access to the current root passwords and other authentication tokens.
+Prior RTPs are any members who were previously an RTP and are not currently on an extension given by the RTPs.
+Prior RTPs are not guaranteed access to any elevated permissions to any systems or networks, including but not limited to the RTP LDAP role, Vault, or the root password.
 The current RTPs may draft rules and regulations specifying the rights and privileges of Prior RTPs.
 
 \asubsubsection{Renewal of a Root Type Person}
 At the conclusion of each academic year, every RTP desiring to maintain their active status for the upcoming academic year must participate in a renewal process. 
-Prior to the vote, the Operational Communications Director shall present a formal statement summarizing each RTP’s contributions and performance. 
-Subsequently, E-Board will conduct an Immediate Relative Majority Vote on each candidate's continuation. 
-RTPs failing to secure the required majority will be mandated to resign their RTP status.
+During the second to last E-Board Meeting of the semester, the Operational Communications Director shall present a formal statement summarizing the contributions and performance of each RTP. 
+After each statement, an E-Board Vote will be conducted to determine each candidate's continuation. 
+If the vote does not pass, that member will become a Prior RTP.
 
 \asubsubsection{Creation of Accounts}
 RTPs have the authority to manage user accounts for CSH systems.
-Before a member may receive an account they must:
+Before a member may receive an account, they must:
 \renewcommand{\theenumi}{\arabic{enumi}} % For this section, we want items to use letters
 \begin{enumerate}
 	\item Sign the Code of Conduct sheets pertaining to the responsible utilization of CSH and RIT facilities.
-	\item Obtain greater than or equal to 60\% of required signatures, excluding those of On-Floor Members who have not passed a Membership Eval, in the Intro Packet or successfully complete Intro Eval.
+	\item Obtain greater than or equal to 60\% of required signatures, excluding those of On-Floor Members who have not passed a Membership Eval, in the Intro Packet, or successfully complete Intro Eval.
 	\item Sign a copy of the Membership Agreement
 \end{enumerate}
 Accounts for Honorary and Advisory Members may be created at the discretion of the RTPs.


### PR DESCRIPTION
Check one:
- [ x ] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
RTPs are no longer RTP for life, RTPs will be give notes to the OpComm Director and Opcomm will give the notes to Eboard and Eboard will vote on the RTP. The outcomes of this vote will be either the RTP will stay on for the next operating session or the RTP will no longer be an active RTP and perms will be removed by the end of the operating session.