### PR TITLE
remove interview mentions from 4.A.2.B

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -172,7 +172,7 @@ They then undergo the selection process as defined below.
 \asubsubsection{Selection Process for Incoming RIT Students}
 \begin{enumerate}
 	\item During spring semester, the Evals Director selects a group of Active Members to form a Selections Committee.
-	      The Selections Committee reviews applications and conducts interviews in accordance with the process prescribed by ResLife.
+	      The Selections Committee reviews applications in accordance with the process prescribed by ResLife.
 	\item A subset of applicants will be offered Intro Membership and have the opportunity to participate in the Intro Process defined in \ref{The Evaluation Period}.
 	      A subset of Intro Members will be offered On-Floor status and will be able to select a room on floor.
 	      The other Intro Members will have Off-Floor status, but will otherwise have the same privileges and responsibilities.


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
closes #258

removes mentions of interviews from the intro process for Incoming RIT students
