### PR TITLE
correct voting member expectations

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -286,7 +286,7 @@ Active Members receive the privilege to:
 The following requirements must be met for an Active Member to be allowed to vote after the first Intro Evals of the academic year.
 Any of these requirements may be waived by the Evals Director or an E-Board Vote.
 \begin{enumerate}
-	\item Attend at least six House Meetings
+	\item Attend all House Meetings
 	\item Attend at least six directorship meetings
 	\item Attend at least one CSH social event
 	\item Attend at least two Technical Seminars


### PR DESCRIPTION
Check one:

- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Clarify that voting members are required to attend all house meetings, not just 6