### PR TITLE
Remove Social Event Requirements

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -212,7 +212,6 @@ Before the end of the Intro Process, an Intro Member is expected to:
 	\item Attend all House Meetings during the Intro Process
 	\item Complete the Intro Packet
 	\item Attend at least one directorship meeting for each week of the process
-	\item Attend at least one CSH social event during the process
 	\item Attend at least two Technical Seminars during the process
 \end{enumerate}
 
@@ -288,7 +287,6 @@ Any of these requirements may be waived by the Evals Director or an E-Board Vote
 \begin{enumerate}
 	\item Attend at least six House Meetings
 	\item Attend at least six directorship meetings
-	\item Attend at least one CSH social event
 	\item Attend at least two Technical Seminars
 \end{enumerate}
 


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Removed the CSH Social Event requirement from both Intro Member and Voting Member expectations.

- Social event attendance is not something we track
- If you don't attend a single social event as an intro member, you're unlikely to pass anyways
- It can be confusing to an intro member as to what counts as a "Social Event"

This differs from https://github.com/ComputerScienceHouse/Constitution/pull/243/files (which failed to pass), as it removes the social event requirement from both intro and voting expectations. I believe the fact that it held upperclassmen to a different standard to intro members was the primary reason this failed.