### PR TITLE
Ensure vote counts dont change during the eval

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -315,7 +315,7 @@ Neither absentee nor proxy votes are allowed.
 \asubsubsubsection{Outcomes}
 Members who pass the Membership Eval have the option to participate as an Active Member in the following year.
 \\* \\*
-If a member fails and has never passed a Membership Eval in the past, their membership will be revoked immediaely upon completion of the Membership Eval
+If a member fails and has never passed a Membership Eval in the past, their membership will be revoked upon completion of the Membership Eval
 If the member fails, but has previously passed a Membership Eval, they will move to Alumni Membership in bad standing, as defined in \ref{Alumni Membership Selection}, at the end of the Standard Operating Session.
 In either case, the member forfeits their ability to participate as an Active Member in the following year.
 \\* \\*


### PR DESCRIPTION
Check one:
- [X] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
If you fail your first spring evals, your membership is now revoked immediately upon completion of the Membership Eval, ensuring that vote counts dont change in the middle of the event.
