### PR TITLE
dual chair, evals, and financials not allowed

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -592,7 +592,7 @@ However, the Chair and at least two-thirds of the Voting Members of E-Board must
 	\item CSH may choose to waive the following subset of the qualifications for E-Board positions, as defined under \ref{Qualifications}, for all candidates:
 	      \begin{enumerate}
 		      \item Candidates must reside on floor during the term of office.
-		      \item Social and R\&D are the only voting E-Board positions that allow for dual directorship.
+		      \item Social and R\&D are the only E-Board positions that allow for dual directorship.
 	      \end{enumerate}
 	\item When a waiver is proposed, the Chair of the Vote shall state which E-Board position and qualification is being voted upon, and any nominated candidates not qualified under \ref{Qualifications} who would become qualified if the waiver passes.
 	\item A Three-Quarters Immediate Vote with three-quarters quorum is then taken to determine whether the proposed waiver shall take effect.
@@ -603,7 +603,7 @@ However, the Chair and at least two-thirds of the Voting Members of E-Board must
 \asubsection{Selection}
 
 \asubsubsection{Dual Directors}
-Social and R\&D are the only Voting E-Board positions that allow for dual directors.
+Social and R\&D are the only E-Board positions that allow for dual directors.
 
 If two candidates elect to run as dual directors, their names are placed together on a single line of the election ballot.
 If they are also nominated as a single directorship or as dual directors with another member, their votes are not cumulative.

--- a/constitution.tex
+++ b/constitution.tex
@@ -598,13 +598,13 @@ However, the Chair and at least two-thirds of the Voting Members of E-Board must
 	\item A Three-Quarters Immediate Vote with three-quarters quorum is then taken to determine whether the proposed waiver shall take effect.
 	\item Each vote to waive a qualification must only apply to a single qualification for a single E-Board position.
 	\item Waivers always apply to all candidates for the E-Board position.
+	\item The waiver for dual directorship may never be applied to the positions of Chair, Evals, or Financials.
 \end{enumerate}
 
 \asubsection{Selection}
 
 \asubsubsection{Dual Directors}
-Social and R\&D are the only E-Board positions that allow for dual directors.
-
+Social and R\&D are the only E-Board positions that allow for dual directors. The positions of Chair, Evals, and Financials must never be held by dual directors.
 If two candidates elect to run as dual directors, their names are placed together on a single line of the election ballot.
 If they are also nominated as a single directorship or as dual directors with another member, their votes are not cumulative.
 Each different nomination must be a separate entry on the election ballot.


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Dual Chair allows for a vote to be tied if E-Board ties and also both chairs disagree
Dual Secretary (the only other non-voting E-Board position) doesn't need to be dual. Needs discussion
