### PR TITLE
Move Alumni to Prior CM Status

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -729,8 +729,12 @@ If the vote passes, E-Board may discuss and make a new ruling by another E-Board
 
 \asection{Constitutional Maintainers}
 
+\asubsection{Constitutional Maintainer Selection}
+Any member may nominate a qualified member for Maintainer status to E-Board for consideration.
+E-Board may choose to approve or reject the nomination by E-Board Vote with a quorum of seventy-five percent.
+
 \asubsection{Constitutional Maintainer Qualifications}
-Maintainers must be Active or Alumni Members.
+Maintainers must be Active Members.
 
 \asubsection{Constitutional Maintainer Expectations}
 Maintainers are expected to:
@@ -743,13 +747,12 @@ Maintainers are expected to:
 Failure to meet any of these expectations is grounds for revocation of Maintainer status by E-Board.
 
 \asubsection{Constitutional Maintainer Term}
-Maintainer status lasts until it is resigned, or until it is revoked by an E-Board Vote.
-A Maintainer may resign at any time by notifying the current E-Board and Maintainer group.
 If a Maintainer no longer satisfies \ref{Constitutional Maintainer Qualifications}, they lose Maintainer status.
+Maintainer status otherwise lasts until it is resigned, or until it is revoked by an E-Board Vote.
+A Maintainer may resign at any time by notifying the current E-Board and Maintainer group.
 
-\asubsection{Constitutional Maintainer Selection}
-Any member may nominate a qualified member for Maintainer status to E-Board for consideration.
-E-Board may choose to approve or reject the nomination by E-Board Vote with a quorum of seventy-five percent.
+\asubsection{Prior Constitutional Maintainers}
+Prior Constitutional Maintainers are those members who are no longer current Active Members and have not been granted an extension by the current Constitutional Maintainers.
 
 \asection{Root Type Persons}
 The OpComm Directorship is responsible for overseeing the implementation of maintenance and upgrades to the CSH computer systems networks.

--- a/constitution.tex
+++ b/constitution.tex
@@ -745,16 +745,12 @@ Maintainers are expected to:
 	\item Keep a public record of changes to the Constitution
 \end{enumerate}
 Failure to meet any of these expectations is grounds for revocation of Maintainer status by E-Board.
-
-\asubsection{Constitutional Maintainer Term}
-If a Maintainer no longer satisfies \ref{Constitutional Maintainer Qualifications}, they lose Maintainer status and move to Prior Maintainer Status.
-Maintainer status otherwise lasts until it is resigned, or until it is revoked by an E-Board Vote.
 A Maintainer may resign at any time by notifying the current E-Board and Maintainer group.
 
 \asubsection{Prior Constitutional Maintainers}
-Prior Constitutional Maintainers are those members who are no longer current Active Members and have not been granted an extension by the current Constitutional Maintainers.
+Prior Constitutional Maintainers are those members who are no longer Active Members and have not been granted an extension by the current Constitutional Maintainers.
 Extensions last until the end of the Standard Operating Session. 
-The current Maintainers may draft rules and regulations specifying the rights and priveleges associated with an extension.
+The current Maintainers may draft rules and regulations specifying the rights and privileges associated with an extension.
 
 \asection{Root Type Persons}
 The OpComm Directorship is responsible for overseeing the implementation of maintenance and upgrades to the CSH computer systems networks.

--- a/constitution.tex
+++ b/constitution.tex
@@ -734,7 +734,7 @@ Any member may nominate a qualified member for Maintainer status to E-Board for 
 E-Board may choose to approve or reject the nomination by E-Board Vote with a quorum of seventy-five percent.
 
 \asubsection{Constitutional Maintainer Qualifications}
-Maintainers must be Active Members.
+Maintainers must be Active Members or Alumni Members with an extension granted to them.
 
 \asubsection{Constitutional Maintainer Expectations}
 Maintainers are expected to:
@@ -747,12 +747,13 @@ Maintainers are expected to:
 Failure to meet any of these expectations is grounds for revocation of Maintainer status by E-Board.
 
 \asubsection{Constitutional Maintainer Term}
-If a Maintainer no longer satisfies \ref{Constitutional Maintainer Qualifications}, they lose Maintainer status.
+If a Maintainer no longer satisfies \ref{Constitutional Maintainer Qualifications}, they lose Maintainer status and move to Prior Maintainer Status.
 Maintainer status otherwise lasts until it is resigned, or until it is revoked by an E-Board Vote.
 A Maintainer may resign at any time by notifying the current E-Board and Maintainer group.
 
 \asubsection{Prior Constitutional Maintainers}
 Prior Constitutional Maintainers are those members who are no longer current Active Members and have not been granted an extension by the current Constitutional Maintainers.
+Extensions last until the end of the Standard Operating Session.
 
 \asection{Root Type Persons}
 The OpComm Directorship is responsible for overseeing the implementation of maintenance and upgrades to the CSH computer systems networks.

--- a/constitution.tex
+++ b/constitution.tex
@@ -734,7 +734,7 @@ Any member may nominate a qualified member for Maintainer status to E-Board for 
 E-Board may choose to approve or reject the nomination by E-Board Vote with a quorum of seventy-five percent.
 
 \asubsection{Constitutional Maintainer Qualifications}
-Maintainers must be Active Members or Alumni Members with an extension granted to them.
+Candidates must be Active Members
 
 \asubsection{Constitutional Maintainer Expectations}
 Maintainers are expected to:
@@ -753,7 +753,8 @@ A Maintainer may resign at any time by notifying the current E-Board and Maintai
 
 \asubsection{Prior Constitutional Maintainers}
 Prior Constitutional Maintainers are those members who are no longer current Active Members and have not been granted an extension by the current Constitutional Maintainers.
-Extensions last until the end of the Standard Operating Session.
+Extensions last until the end of the Standard Operating Session. 
+The current Maintainers may draft rules and regulations specifying the rights and priveleges associated with an extension.
 
 \asection{Root Type Persons}
 The OpComm Directorship is responsible for overseeing the implementation of maintenance and upgrades to the CSH computer systems networks.


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

Redefine requirements for active CM to be active member
Create definition of prior CM as previous actives that are no longer meeting requirement (Active), but can be given privileges if deemed necessary by the active CMs on a case by case basis
Clarify the expectations are for active CM, and becoming an alumni automatically moves you to Prior CM status
Organizes sections to follow the order outlined in 5.C.
