### PR TITLE
Remove Financials from Active Chair line of succession

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -685,8 +685,7 @@ To postpone such a selection, the Chair may chair an Immediate Relative Majority
 If there is not an acting Chair during a process where one is required, then the following line of succession is used to determine which director becomes the acting Chair until a new Chair is elected.
 \begin{enumerate}
 	\item[1.] Evals Director
-	\item[2.] Financials Director
-	\item[3.] Voting E-Board Member chosen by an E-Board Vote
+	\item[2.] Voting E-Board Member chosen by an E-Board Vote
 \end{enumerate}
 
 \asubsection{Appointment of an Interim Director}


### PR DESCRIPTION
See that awful thread from 2025-02-26 in #constitution

Check one:
- [X] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

Financials has been removed from the line of succession for Acting Chair; it is now just Evals, then any voting EBoard member, as chosen by an EBoard vote. The reason for this is that while the responsibilities of Evals generally align with those of the Chair (interface with RIT, lead discussions), Financials doesn't need to be as good at leading complex meetings like House Meeting, EBoard Meeting, or Spring Evals. In these situations, EBoard should be allowed to pick a different chair of the discussion than Financials. If Chair is unavailable long-term, a new Chair should be elected instead (and therefore the Acting Chair line of succession is ignored).