### PR TITLE
Rename outcomes sections for clarity

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -224,9 +224,9 @@ On a member-by-member basis, the Intro Eval determines if each Intro Member has 
 An Immediate Relative Majority Vote with two-thirds quorum is required for the Eval to be valid.
 For an Active Member to be eligible to vote during the Intro Eval they must meet the requirements outlined in \ref{Expectations of Voting Members}.
 Neither absentee nor proxy votes are allowed.
-Intro Members may be offered any of the outcomes listed in \ref{Outcomes}.
+Intro Members may be offered any of the outcomes listed in \ref{Intro Eval Outcomes}.
 
-\asubsubsubsection{Outcomes}
+\asubsubsubsection{Intro Eval Outcomes}
 \renewcommand{\theenumi}{\alph{enumi}} % For this section, we want items to use letters
 \begin{enumerate}
 	\item Intro Members may be offered Active Membership provided they meet the requirements described in \ref{Expectations of an Introductory Member}, at the discretion of attending members.
@@ -314,7 +314,7 @@ These requirements must be completed before the Membership Eval occurs.
 A Secret Immediate Relative Majority vote with two-thirds quorum is required for the evaluation to be valid.
 Neither absentee nor proxy votes are allowed.
 
-\asubsubsubsection{Outcomes}
+\asubsubsubsection{Membership Eval Outcomes}
 Members who pass the Membership Eval have the option to participate as an Active Member in the following year.
 \\* \\*
 If a member fails and has never passed a Membership Eval in the past, their membership will be revoked upon completion of the Membership Eval

--- a/constitution.tex
+++ b/constitution.tex
@@ -224,9 +224,9 @@ On a member-by-member basis, the Intro Eval determines if each Intro Member has 
 An Immediate Relative Majority Vote with two-thirds quorum is required for the Eval to be valid.
 For an Active Member to be eligible to vote during the Intro Eval they must meet the requirements outlined in \ref{Expectations of Voting Members}.
 Neither absentee nor proxy votes are allowed.
-Intro Members may be offered any of the outcomes listed in \ref{Intro Eval Outcomes}.
+Intro Members may be offered any of the outcomes listed in \ref{Introductory Evaluation Outcomes}.
 
-\asubsubsubsection{Intro Eval Outcomes}
+\asubsubsubsection{Introductory Evaluation Outcomes}
 \renewcommand{\theenumi}{\alph{enumi}} % For this section, we want items to use letters
 \begin{enumerate}
 	\item Intro Members may be offered Active Membership provided they meet the requirements described in \ref{Expectations of an Introductory Member}, at the discretion of attending members.
@@ -314,7 +314,7 @@ These requirements must be completed before the Membership Eval occurs.
 A Secret Immediate Relative Majority vote with two-thirds quorum is required for the evaluation to be valid.
 Neither absentee nor proxy votes are allowed.
 
-\asubsubsubsection{Membership Eval Outcomes}
+\asubsubsubsection{Membership Evaluation Outcomes}
 Members who pass the Membership Eval have the option to participate as an Active Member in the following year.
 \\* \\*
 If a member fails and has never passed a Membership Eval in the past, their membership will be revoked upon completion of the Membership Eval


### PR DESCRIPTION
It was mislinking "outcomes listed in {Outcomes}" to the Outcomes for Membership Evals since both subsections were named Outcomes. I have renamed one to Membership Eval Outcomes and the other to Intro Eval Outcomes.

Check one:
- Semantic Change: something about the meaning of the text is different
- [x] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

Both Subsections being {Outcomes} -> {Intro Eval Outcomes} and {Membership Eval Outcomes}

