### PR TITLE
Allow hosting a Technical seminar to pass Gatekeep/6 Weeks

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -212,7 +212,7 @@ Before the end of the Intro Process, an Intro Member is expected to:
 	\item Attend all House Meetings during the Intro Process
 	\item Complete the Intro Packet
 	\item Attend at least one directorship meeting for each week of the process
-	\item Attend at least two Technical Seminars during the process
+	\item Attend at least two or host at least one Technical Seminar(s) during the process
 \end{enumerate}
 
 \asubsubsection{Introductory Evaluation}
@@ -291,7 +291,7 @@ The waiver will last until the end of the semester, or until there is a negative
 \begin{enumerate}
 	\item Attend all House Meetings, being absent no more than once per academic semester
 	\item Attend at least six directorship meetings
-	\item Attend at least two Technical Seminars
+	\item Attend at least two or host at least one Technical Seminar(s)
 \end{enumerate}
 
 \asubsection{Active Membership Evaluations}


### PR DESCRIPTION
Check one:
- [X] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Allow the option of hosting a technical seminar to count for the Technical Seminar requirement for gatekeep/six weeks.
This would (ideally) motivate people to host more technical seminars.