### PR TITLE
Make technical seminars not have to be related to computers

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -87,7 +87,7 @@
 
 % Formatted as term | definition
 \begin{tabular}{l l}
-	Technical Seminar          & \textit{Seminar relating to computing or electronics}                                     \\
+	Technical Seminar          & \textit{Seminar relating to real-world skills or knowledge}                                     \\
 	Standard Operating Session & \textit{RIT's fall and spring semesters, excluding institute breaks and final exam weeks} \\
 	Total Expenditure          & \textit{Funds drawn for a specific event, project, piece of equipment, or service}
 \end{tabular}


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Make technical seminar definition be a seminar relating to real-world skills or knowledge
