### PR TITLE
Active Members host at least one Technical Seminar

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -273,8 +273,8 @@ Active Members are required to:
 	\item Have signed a copy of the Membership Agreement
 	\item Attend all House Meetings and E-Board candidate speeches
 	\item Attend at least fifteen directorship meetings for each semester in which they are an Active Member
-	\item Participate in at least one \ref{Major Project}
-	\item Host at least one Technical seminar or pass a Technical \ref{Major Project}
+	\item Participate in at least one Major Project as defined in \ref{Major Project}
+	\item Host at least one Technical seminar or pass at least one Technical Major Project
 \end{enumerate}
 
 \asubsubsubsection{Major Project}
@@ -476,7 +476,7 @@ A Voting E-Board Member is considered to be any E-Board Member with a non-zero v
 	\item To report pertinent information to members at the following House Meeting
 	\item To maintain records of the goals defined by each previous E-Board
 	\item To act as a Judicial Board as defined in \ref{Judicial}
-	\item To review \ref{Major Project}s as defined in \ref{Expectations of Active Members}
+	\item To review Major Projects as defined in \ref{Expectations of Active Members}
 	\item To make the final vote regarding conditionals and appeals as defined in \ref{Membership Evaluation}
 	\item To respect the privacy of members confiding in E-Board, barring situations related to sexual assault or endangerment of oneself or others
 	\item To publish a document at the end of each semester to all members stating CSH's accomplishments of that semester
@@ -539,7 +539,7 @@ A Voting E-Board Member is considered to be any E-Board Member with a non-zero v
 	\item To oversee the planning, organization, and construction of technical projects for the CSH's benefit
 	\item To strive to fulfill the CSH's need for technical equipment
 	\item To organize and support seminars
-	\item To determine if a \ref{Major Project} or seminar is Technical
+	\item To determine if a Major Project or seminar is Technical
 	\item To vote on issues presented to E-Board
 \end{enumerate}
 

--- a/constitution.tex
+++ b/constitution.tex
@@ -263,6 +263,7 @@ Voting Members are expected to meet the requirements defined in \ref{Expectation
 \asubsubsection{Expectations of Active Members}
 Active Members are required to pay dues as stated in \ref{Collection of Dues}, attend all House Meetings and E-Board candidate speeches, and attend at least fifteen of the directorship meetings for each semester in which they are an Active Member.
 They are also expected to sign a copy of the Membership Agreement.
+Active Members should also host at least one Technical Seminar during the academic year.
 \\* \\*
 Active Members must participate in at least one major project during the academic year.
 Members are required to submit a description for this major project to E-Board for approval.

--- a/constitution.tex
+++ b/constitution.tex
@@ -275,7 +275,7 @@ Active Members are required to:
 	\item Attend at least fifteen directorship meetings for each semester in which they are an Active Member
 	\item Host at least one Technical seminar or pass a Technical major project
 \end{enumerate}
-\\* \\*
+
 Active Members must participate in at least one major project during the academic year.
 Members are required to submit a description for this major project to E-Board for approval.
 As an alternative to this requirement, members may instead assist on a large number of CSH activities and projects.

--- a/constitution.tex
+++ b/constitution.tex
@@ -270,10 +270,10 @@ Voting Members are expected to meet the requirements defined in \ref{Expectation
 Active Members are required to:
 \begin{enumerate}
 	\item Pay dues as stated in \ref{Collection of Dues}
+	\item Have signed a copy of the Membership Agreement
 	\item Attend all House Meetings and E-Board candidate speeches
-	\item Attend at least fifteen directorship meetings for each semester in which they are an Active Member.
-	\item Sign a copy of the Membership Agreement.
-	\item Host at least one Technical seminar or pass a Technical major project.
+	\item Attend at least fifteen directorship meetings for each semester in which they are an Active Member
+	\item Host at least one Technical seminar or pass a Technical major project
 \end{enumerate}
 \\* \\*
 Active Members must participate in at least one major project during the academic year.

--- a/constitution.tex
+++ b/constitution.tex
@@ -87,7 +87,8 @@
 
 % Formatted as term | definition
 \begin{tabular}{l l}
-	Technical Seminar          & \textit{Seminar relating to computing or electronics}                                     \\
+	Technical                  & \textit{Relevant to computing or electronics} \\
+	Technical Seminar          & \textit{A seminar containing Technical practical knowledge} \\
 	Standard Operating Session & \textit{RIT's fall and spring semesters, excluding institute breaks and final exam weeks} \\
 	Total Expenditure          & \textit{Funds drawn for a specific event, project, piece of equipment, or service}
 \end{tabular}
@@ -261,9 +262,14 @@ Active Members are expected to be active participants in CSH as defined in \ref{
 Voting Members are expected to meet the requirements defined in \ref{Expectations of Voting Members}.
 
 \asubsubsection{Expectations of Active Members}
-Active Members are required to pay dues as stated in \ref{Collection of Dues}, attend all House Meetings and E-Board candidate speeches, and attend at least fifteen of the directorship meetings for each semester in which they are an Active Member.
-They are expected to sign a copy of the Membership Agreement.
-Active Members must host at least one Technical Seminar.
+Active Members are required to:
+\begin{enumerate}
+	\item Pay dues as stated in \ref{Collection of Dues}
+	\item Attend all House Meetings and E-Board candidate speeches
+	\item Attend at least fifteen directorship meetings for each semester in which they are an Active Member.
+	\item Sign a copy of the Membership Agreement.
+	\item Host at least one Technical Seminar or pass a Technical major project.
+\end{enumerate}
 \\* \\*
 Active Members must participate in at least one major project during the academic year.
 Members are required to submit a description for this major project to E-Board for approval.
@@ -528,6 +534,7 @@ A Voting E-Board Member is considered to be any E-Board Member with a non-zero v
 	\item To oversee the planning, organization, and construction of technical projects for the CSH's benefit
 	\item To strive to fulfill the CSH's need for technical equipment
 	\item To organize and support Technical Seminars
+	\item To approve Technical major projects
 	\item To vote on issues presented to E-Board
 \end{enumerate}
 

--- a/constitution.tex
+++ b/constitution.tex
@@ -262,8 +262,8 @@ Voting Members are expected to meet the requirements defined in \ref{Expectation
 
 \asubsubsection{Expectations of Active Members}
 Active Members are required to pay dues as stated in \ref{Collection of Dues}, attend all House Meetings and E-Board candidate speeches, and attend at least fifteen of the directorship meetings for each semester in which they are an Active Member.
-They are also expected to sign a copy of the Membership Agreement.
-Active Members should also host at least one Technical Seminar during the academic year.
+They are expected to sign a copy of the Membership Agreement.
+Active Members must host at least one Technical Seminar.
 \\* \\*
 Active Members must participate in at least one major project during the academic year.
 Members are required to submit a description for this major project to E-Board for approval.

--- a/constitution.tex
+++ b/constitution.tex
@@ -94,7 +94,6 @@
 % Formatted as term | definition
 \begin{tabular}{l l}
 	Technical                  & \textit{Relevant to computing or electronics} \\
-	Technical Seminar          & \textit{A seminar containing Technical practical knowledge} \\
 	Standard Operating Session & \textit{RIT's fall and spring semesters, excluding institute breaks and final exam weeks} \\
 	Total Expenditure          & \textit{Funds drawn for a specific event, project, piece of equipment, or service}
 \end{tabular}
@@ -219,7 +218,7 @@ Before the end of the Intro Process, an Intro Member is expected to:
 	\item Attend all House Meetings during the Intro Process
 	\item Complete the Intro Packet
 	\item Attend at least one directorship meeting for each week of the process
-	\item Attend at least two or host at least one Technical Seminar(s) during the process
+	\item Attend at least two or host at least one Technical seminar(s) during the process
 \end{enumerate}
 
 \asubsubsection{Introductory Evaluation}
@@ -274,7 +273,7 @@ Active Members are required to:
 	\item Attend all House Meetings and E-Board candidate speeches
 	\item Attend at least fifteen directorship meetings for each semester in which they are an Active Member.
 	\item Sign a copy of the Membership Agreement.
-	\item Host at least one Technical Seminar or pass a Technical major project.
+	\item Host at least one Technical seminar or pass a Technical major project.
 \end{enumerate}
 \\* \\*
 Active Members must participate in at least one major project during the academic year.
@@ -303,7 +302,7 @@ The waiver will last until the end of the semester, or until there is a negative
 \begin{enumerate}
 	\item Attend all House Meetings, being absent no more than once per academic semester
 	\item Attend at least six directorship meetings
-	\item Attend at least two or host at least one Technical Seminar(s)
+	\item Attend at least two or host at least one Technical seminar(s)
 \end{enumerate}
 
 \asubsection{Active Membership Evaluations}
@@ -538,12 +537,8 @@ A Voting E-Board Member is considered to be any E-Board Member with a non-zero v
 	\item To exercise general supervision over R\&D operations
 	\item To oversee the planning, organization, and construction of technical projects for the CSH's benefit
 	\item To strive to fulfill the CSH's need for technical equipment
-<<<<<<< HEAD
-	\item To organize and support Technical Seminars
-	\item To approve Technical major projects
-=======
-	\item To organize, support, and approve Technical Seminars
->>>>>>> master
+	\item To organize and support seminars
+	\item To approve Technical major projects and Technical seminars
 	\item To vote on issues presented to E-Board
 \end{enumerate}
 

--- a/constitution.tex
+++ b/constitution.tex
@@ -476,7 +476,7 @@ A Voting E-Board Member is considered to be any E-Board Member with a non-zero v
 	\item To report pertinent information to members at the following House Meeting
 	\item To maintain records of the goals defined by each previous E-Board
 	\item To act as a Judicial Board as defined in \ref{Judicial}
-	\item To review Major Projects as defined in \ref{Expectations of Active Members}
+	\item To review Major Projects as defined in \ref{Major Project}
 	\item To make the final vote regarding conditionals and appeals as defined in \ref{Membership Evaluation}
 	\item To respect the privacy of members confiding in E-Board, barring situations related to sexual assault or endangerment of oneself or others
 	\item To publish a document at the end of each semester to all members stating CSH's accomplishments of that semester

--- a/constitution.tex
+++ b/constitution.tex
@@ -93,7 +93,7 @@
 
 % Formatted as term | definition
 \begin{tabular}{l l}
-	Technical                  & \textit{Relevant to computing or electronics} \\
+	Technical                  & \textit{Practical knowledge relevant to computing or electronics} \\
 	Standard Operating Session & \textit{RIT's fall and spring semesters, excluding institute breaks and final exam weeks} \\
 	Total Expenditure          & \textit{Funds drawn for a specific event, project, piece of equipment, or service}
 \end{tabular}
@@ -538,7 +538,7 @@ A Voting E-Board Member is considered to be any E-Board Member with a non-zero v
 	\item To oversee the planning, organization, and construction of technical projects for the CSH's benefit
 	\item To strive to fulfill the CSH's need for technical equipment
 	\item To organize and support seminars
-	\item To approve Technical major projects and Technical seminars
+	\item To approve if a major project or seminar is Technical
 	\item To vote on issues presented to E-Board
 \end{enumerate}
 

--- a/constitution.tex
+++ b/constitution.tex
@@ -278,7 +278,7 @@ Active Members are required to:
 \end{enumerate}
 
 \asubsubsubsection{Major Project}
-Members are required to submit a description for a major project to E-Board for approval.
+Members are required to submit a description for a Major Project to E-Board for approval.
 In lieu of one singular project, a member may assist on a large number of CSH activities and projects.
 However, it is to be understood in advance by the member that this option requires a great deal of participation throughout the year.
 This participation will be evaluated by E-Board.

--- a/constitution.tex
+++ b/constitution.tex
@@ -273,12 +273,13 @@ Active Members are required to:
 	\item Have signed a copy of the Membership Agreement
 	\item Attend all House Meetings and E-Board candidate speeches
 	\item Attend at least fifteen directorship meetings for each semester in which they are an Active Member
-	\item Host at least one Technical seminar or pass a Technical major project
+	\item Participate in at least one \ref{Major Project}
+	\item Host at least one Technical seminar or pass a Technical \ref{Major Project}
 \end{enumerate}
 
-Active Members must participate in at least one major project during the academic year.
-Members are required to submit a description for this major project to E-Board for approval.
-As an alternative to this requirement, members may instead assist on a large number of CSH activities and projects.
+\asubsubsubsection{Major Project}
+Members are required to submit a description for a major project to E-Board for approval.
+In lieu of one singular project, a member may assist on a large number of CSH activities and projects.
 However, it is to be understood in advance by the member that this option requires a great deal of participation throughout the year.
 This participation will be evaluated by E-Board.
 
@@ -475,7 +476,7 @@ A Voting E-Board Member is considered to be any E-Board Member with a non-zero v
 	\item To report pertinent information to members at the following House Meeting
 	\item To maintain records of the goals defined by each previous E-Board
 	\item To act as a Judicial Board as defined in \ref{Judicial}
-	\item To review major projects as defined in \ref{Expectations of Active Members}
+	\item To review \ref{Major Project}s as defined in \ref{Expectations of Active Members}
 	\item To make the final vote regarding conditionals and appeals as defined in \ref{Membership Evaluation}
 	\item To respect the privacy of members confiding in E-Board, barring situations related to sexual assault or endangerment of oneself or others
 	\item To publish a document at the end of each semester to all members stating CSH's accomplishments of that semester
@@ -538,7 +539,7 @@ A Voting E-Board Member is considered to be any E-Board Member with a non-zero v
 	\item To oversee the planning, organization, and construction of technical projects for the CSH's benefit
 	\item To strive to fulfill the CSH's need for technical equipment
 	\item To organize and support seminars
-	\item To determine if a major project or seminar is Technical
+	\item To determine if a \ref{Major Project} or seminar is Technical
 	\item To vote on issues presented to E-Board
 \end{enumerate}
 

--- a/constitution.tex
+++ b/constitution.tex
@@ -538,7 +538,7 @@ A Voting E-Board Member is considered to be any E-Board Member with a non-zero v
 	\item To oversee the planning, organization, and construction of technical projects for the CSH's benefit
 	\item To strive to fulfill the CSH's need for technical equipment
 	\item To organize and support seminars
-	\item To approve if a major project or seminar is Technical
+	\item To determine if a major project or seminar is Technical
 	\item To vote on issues presented to E-Board
 \end{enumerate}
 

--- a/constitution.tex
+++ b/constitution.tex
@@ -269,6 +269,7 @@ Voting Members are expected to meet the requirements defined in \ref{Expectation
 \asubsubsection{Expectations of Active Members}
 Active Members are required to pay dues as stated in \ref{Collection of Dues}, attend all House Meetings and E-Board candidate speeches, and attend at least fifteen of the directorship meetings for each semester in which they are an Active Member.
 They are also expected to sign a copy of the Membership Agreement.
+Active Members should also host at least one Technical Seminar during the academic year.
 \\* \\*
 Active Members must participate in at least one major project during the academic year.
 Members are required to submit a description for this major project to E-Board for approval.

--- a/constitution.tex
+++ b/constitution.tex
@@ -268,8 +268,8 @@ Voting Members are expected to meet the requirements defined in \ref{Expectation
 
 \asubsubsection{Expectations of Active Members}
 Active Members are required to pay dues as stated in \ref{Collection of Dues}, attend all House Meetings and E-Board candidate speeches, and attend at least fifteen of the directorship meetings for each semester in which they are an Active Member.
-They are also expected to sign a copy of the Membership Agreement.
-Active Members should also host at least one Technical Seminar during the academic year.
+They are expected to sign a copy of the Membership Agreement.
+Active Members must host at least one Technical Seminar.
 \\* \\*
 Active Members must participate in at least one major project during the academic year.
 Members are required to submit a description for this major project to E-Board for approval.

--- a/constitution.tex
+++ b/constitution.tex
@@ -94,7 +94,6 @@
 % Formatted as term | definition
 \begin{tabular}{l l}
 	Technical                  & \textit{Relevant to computing or electronics} \\
-	Technical Seminar          & \textit{A seminar containing Technical practical knowledge} \\
 	Standard Operating Session & \textit{RIT's fall and spring semesters, excluding institute breaks and final exam weeks} \\
 	Total Expenditure          & \textit{Funds drawn for a specific event, project, piece of equipment, or service}
 \end{tabular}
@@ -219,7 +218,7 @@ Before the end of the Intro Process, an Intro Member is expected to:
 	\item Attend all House Meetings during the Intro Process
 	\item Complete the Intro Packet
 	\item Attend at least one directorship meeting for each week of the process
-	\item Attend at least two or host at least one Technical Seminar(s) during the process
+	\item Attend at least two or host at least one Technical seminar(s) during the process
 \end{enumerate}
 
 \asubsubsection{Introductory Evaluation}
@@ -274,7 +273,7 @@ Active Members are required to:
 	\item Attend all House Meetings and E-Board candidate speeches
 	\item Attend at least fifteen directorship meetings for each semester in which they are an Active Member.
 	\item Sign a copy of the Membership Agreement.
-	\item Host at least one Technical Seminar or pass a Technical major project.
+	\item Host at least one Technical seminar or pass a Technical major project.
 \end{enumerate}
 \\* \\*
 Active Members must participate in at least one major project during the academic year.
@@ -303,7 +302,7 @@ The waiver will last until the end of the semester, or until there is a negative
 \begin{enumerate}
 	\item Attend all House Meetings, being absent no more than once per academic semester
 	\item Attend at least six directorship meetings
-	\item Attend at least two or host at least one Technical Seminar(s)
+	\item Attend at least two or host at least one Technical seminar(s)
 \end{enumerate}
 
 \asubsection{Active Membership Evaluations}
@@ -538,8 +537,8 @@ A Voting E-Board Member is considered to be any E-Board Member with a non-zero v
 	\item To exercise general supervision over R\&D operations
 	\item To oversee the planning, organization, and construction of technical projects for the CSH's benefit
 	\item To strive to fulfill the CSH's need for technical equipment
-	\item To organize and support Technical Seminars
-	\item To approve Technical major projects
+	\item To organize and support seminars
+	\item To approve Technical major projects and Technical seminars
 	\item To vote on issues presented to E-Board
 \end{enumerate}
 

--- a/constitution.tex
+++ b/constitution.tex
@@ -93,7 +93,8 @@
 
 % Formatted as term | definition
 \begin{tabular}{l l}
-	Technical Seminar          & \textit{Seminar on practical knowledge relevant to computing or electronics} \\                                     
+	Technical                  & \textit{Relevant to computing or electronics} \\
+	Technical Seminar          & \textit{A seminar containing Technical practical knowledge} \\
 	Standard Operating Session & \textit{RIT's fall and spring semesters, excluding institute breaks and final exam weeks} \\
 	Total Expenditure          & \textit{Funds drawn for a specific event, project, piece of equipment, or service}
 \end{tabular}
@@ -267,9 +268,14 @@ Active Members are expected to be active participants in CSH as defined in \ref{
 Voting Members are expected to meet the requirements defined in \ref{Expectations of Voting Members}.
 
 \asubsubsection{Expectations of Active Members}
-Active Members are required to pay dues as stated in \ref{Collection of Dues}, attend all House Meetings and E-Board candidate speeches, and attend at least fifteen of the directorship meetings for each semester in which they are an Active Member.
-They are expected to sign a copy of the Membership Agreement.
-Active Members must host at least one Technical Seminar.
+Active Members are required to:
+\begin{enumerate}
+	\item Pay dues as stated in \ref{Collection of Dues}
+	\item Attend all House Meetings and E-Board candidate speeches
+	\item Attend at least fifteen directorship meetings for each semester in which they are an Active Member.
+	\item Sign a copy of the Membership Agreement.
+	\item Host at least one Technical Seminar or pass a Technical major project.
+\end{enumerate}
 \\* \\*
 Active Members must participate in at least one major project during the academic year.
 Members are required to submit a description for this major project to E-Board for approval.
@@ -532,7 +538,8 @@ A Voting E-Board Member is considered to be any E-Board Member with a non-zero v
 	\item To exercise general supervision over R\&D operations
 	\item To oversee the planning, organization, and construction of technical projects for the CSH's benefit
 	\item To strive to fulfill the CSH's need for technical equipment
-	\item To organize, support, and approve Technical Seminars
+	\item To organize and support Technical Seminars
+	\item To approve Technical major projects
 	\item To vote on issues presented to E-Board
 \end{enumerate}
 


### PR DESCRIPTION
This adds a requirement to being an Active Member, which is that every Active Member must host at least one Technical Seminar during the academic year, and will be evaluated as part of a Membership Eval.

**Common concerns and solutions:**
C: "Some people are really averse to presenting."
S: Presentations are part of the curriculum for most if not all majors at RIT, as well as your professional career. This is GREAT practice for those times, since attendance will likely be 10-20 people, which is less than your average RIT class. It is also much less pressure than that of a job. It's not unfair to ask members of house to do this if they are expected to do it in class and/or in the field, and it's great practice for those who are averse to presenting.

(I'll add more as I see more concerns)

Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.


Summary of change(s):

