### PR TITLE
289 making titles / substitle have consistent spacing

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -41,17 +41,23 @@
 \renewcommand{\thesubsubsection}{\arabic{section}.\Alph{subsection}.\arabic{subsubsection}}
 \titleformat{\section}{\normalfont\Large\bfseries}{Article \thesection}{1em}{}
 \titleformat{\subsection}{\normalfont\large\bfseries}{Section \thesubsection}{1em}{}
+\titleformat{\subsubsection}{\normalfont\normalsize\bfseries}{\thesubsubsection}{1em}{}
+\titlespacing*{\subsubsection}{0pt}{3.25ex plus 1ex minus .2ex}{0.5em}
 
 % Adding an \asubsubsection -- I feel dirty
 %\setcounter{secnumdepth}{5}
 \newcommand{\asubsubsection}[1]{\paragraph{#1} \label{#1}}
 \renewcommand{\theparagraph}{\arabic{section}.\Alph{subsection}.\arabic{subsubsection}.\Alph{paragraph}}
+\titleformat{\paragraph}[block]{\normalfont\normalsize\bfseries}{\theparagraph}{1em}{}
+\titlespacing*{\paragraph}{0pt}{3.25ex plus 1ex minus .2ex}{0.5em}
 
 % Adding \a(sub){3,4}section during merge of bylaws and articles -- I feel _really_ dirty
 \setcounter{secnumdepth}{7}
 \setcounter{tocdepth}{7}
-\newcommand{\asubsubsubsection}[1]{\parindent=0em\subparagraph{#1} \label{#1}}
+\newcommand{\asubsubsubsection}[1]{\subparagraph{#1} \label{#1}}
 \renewcommand{\thesubparagraph}{\arabic{section}.\Alph{subsection}.\arabic{subsubsection}.\Alph{paragraph}.\arabic{subparagraph}}
+\titleformat{\subparagraph}[block]{\normalfont\normalsize\bfseries}{\thesubparagraph}{1em}{}
+\titlespacing*{\subparagraph}{0pt}{3.25ex plus 1ex minus .2ex}{0.5em}
 
 \newcounter{asubsubsubsubsection}[subparagraph]
 \renewcommand{\theasubsubsubsubsection}{\arabic{section}.\Alph{subsection}.\arabic{subsubsection}.\Alph{paragraph}.\arabic{subparagraph}.\Alph{asubsubsubsubsection}}

--- a/constitution.tex
+++ b/constitution.tex
@@ -617,7 +617,6 @@ However, the Chair and at least two-thirds of the Voting Members of E-Board must
 
 \asubsubsection{Dual Directors}
 Social and R\&D are the only Voting E-Board positions that allow for dual directors.
-
 If two candidates elect to run as dual directors, their names are placed together on a single line of the election ballot.
 If they are also nominated as a single directorship or as dual directors with another member, their votes are not cumulative.
 Each different nomination must be a separate entry on the election ballot.
@@ -951,7 +950,7 @@ Votes are cast on ballots that provide a means to indicate every possible option
 For constitutional modification, candidate selection, and officer removal votes, the voting period must be at least forty-eight hours in length.
 For any other type of vote, the voting period must be at least twenty-four hours.
 The minimum length of the voting period may be explicitly lengthened, but never shortened, in the text describing the actual vote.
-
+\\* \\*
 The voting period opens once ballots are distributed to each member eligible to cast a vote.
 At the end of the voting period, the Chair of the Vote collects the ballots, closing the voting period.
 The Vote Counters then tally the results.
@@ -990,7 +989,6 @@ The fraction is specified in the text describing the vote, for example, "Two-Thi
 
 \asubsection{Ranked Choice}
 In a Ranked Choice Vote, voters rank the options by placing a '1' by their first choice, a '2' by their second choice, and so on, until they no longer wish to express any further preferences or run out of options.
-
 The winning option is selected outright if it gains more than half the votes cast as a first preference.
 If not, the option with the fewest number of first preference votes is eliminated and their votes move to the second preference marked on the ballots.
 This process continues until one option has half of the votes cast and is elected.

--- a/constitution.tex
+++ b/constitution.tex
@@ -284,7 +284,6 @@ Active Members receive the privilege to:
 	\item Use CSH facilities
 	\item Receive priority for on-floor housing, or apply for On-Floor Status
 \end{enumerate}
-
 Active Members currently on co-op forfeit their right to vote on house issues, and likewise do not count towards quorum.
 Exceptions may be made at the discretion of the Evaluations Director.
 
@@ -621,7 +620,6 @@ If two candidates elect to run as dual directors, their names are placed togethe
 If they are also nominated as a single directorship or as dual directors with another member, their votes are not cumulative.
 Each different nomination must be a separate entry on the election ballot.
 Ad Hoc Directors are not restricted to single or dual directors.
-
 The following special cases cover the operation of dual directors:
 \begin{enumerate}
 	\item If one of the members in a dual directorship resigns, or for any other reason ends the term of office, the other member in the dual directorship must also step down and the office becomes vacated.
@@ -854,7 +852,6 @@ After this date, dues collection is suspended until the start of the next academ
 		\\ \hline
 	\end{tabular}
 \end{center}
-
 % The suggested total operating budget is $8360.
 % This figure comes from having approximately 55 on-floor members with $80 per semester dues (totaling $8800) minus 5% set aside for Accumulated.
 Dues collected from on-floor members are to be distributed into directorship budgets as shown in the above table.


### PR DESCRIPTION
subsections now all have a newline after them when appropriate using titlesec 

added title format title spacing to \asubsection \asubsubsection \asubsubsubsection

Check one:
- [ ] Semantic Change: something about the meaning of the text is different
- [x] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

My change
<img width="920" height="946" alt="image" src="https://github.com/user-attachments/assets/1279a033-49fa-4cc0-a4c4-0ec080433b4e" />


Live render
<img width="920" height="946" alt="image" src="https://github.com/user-attachments/assets/869deecc-e571-4774-8317-b854002ddadb" />

Note the urls for confirmation