### PR TITLE
conflict

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -129,6 +129,7 @@ Alternatively, the change may be presented at a House Meeting for discussion fol
 Any semantic change to the Constitution requires the change to be proposed in writing for discussion at a House Meeting.
 Any modifications made due to the discussion are added to the written proposal and the modified proposal is posted during the week.
 The final proposal is presented the following week, and ballots are distributed for a Balloted Two-Thirds Vote with two-thirds quorum as described in \ref{Balloted Vote}.
+If two or more modifications are conflicting, ballots are distributed for a Balloted Vote with two-thirds quorum, and a winner is selected as described in \ref{Ranked Choice}.
 The ballots are collected for a minimum of a forty-eight hour period.
 A quorum of two-thirds of Eligible Votes must cast ballots for the vote to be official.
 A vote equaling or exceeding two-thirds of the number of Votes Cast is required for the change to be placed into the Constitution.

--- a/constitution.tex
+++ b/constitution.tex
@@ -129,7 +129,7 @@ Alternatively, the change may be presented at a House Meeting for discussion fol
 Any semantic change to the Constitution requires the change to be proposed in writing for discussion at a House Meeting.
 Any modifications made due to the discussion are added to the written proposal and the modified proposal is posted during the week.
 The final proposal is presented the following week, and ballots are distributed for a Balloted Two-Thirds Vote with two-thirds quorum as described in \ref{Balloted Vote}.
-If two or more modifications are conflicting, ballots are distributed for a Balloted Vote with two-thirds quorum, and a winner is selected as described in \ref{Ranked Choice}.
+If two or more modifications would conflict with one another, at the discretion of the Maintainers, ballots are distributed for a Balloted Vote with two-thirds quorum, and a winner is selected as described in \ref{Ranked Choice}.
 The ballots are collected for a minimum of a forty-eight hour period.
 A quorum of two-thirds of Eligible Votes must cast ballots for the vote to be official.
 A vote equaling or exceeding two-thirds of the number of Votes Cast is required for the change to be placed into the Constitution.


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Codify conflicting amendments being allowed to be ranked choice