### PR TITLE
Co-op and Leave of Absence Edits

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -237,6 +237,7 @@ Intro Members may be offered any of the outcomes listed in \ref{Introductory Eva
 
 \asubsection{Introductory Membership Leave of Absence}
 An Intro Member may request a Leave of Absence through the process described in \ref{Leave of Absence}.
+An Intro Member may request their evaluation period to be extended by the duration of the leave or to end of the Standard Operating Session, whichever comes first.
 
 \asubsection{Introductory Membership Resignations}
 Intro Members may resign by submitting a request for termination of membership to the Chair or the Evals Director in writing before the completion of the Intro Process.
@@ -261,8 +262,10 @@ Active Members are expected to be active participants in CSH as defined in \ref{
 Voting Members are expected to meet the requirements defined in \ref{Expectations of Voting Members}.
 
 \asubsubsection{Expectations of Active Members}
-Active Members are required to pay dues as stated in \ref{Collection of Dues}, attend all House Meetings and E-Board candidate speeches, and attend at least fifteen of the directorship meetings for each semester in which they are an Active Member.
+Active Members are required to pay dues as stated in \ref{Collection of Dues}, attend all House Meetings and E-Board candidate speeches, and attend at least fifteen of the directorship meetings for each semester in which they are an Active Member and not on leave as described in /ref{Active Membership Co-op and Leave of Absence}
 They are also expected to sign a copy of the Membership Agreement.
+
+
 \\* \\*
 Active Members must participate in at least one major project during the academic year.
 Members are required to submit a description for this major project to E-Board for approval.
@@ -329,16 +332,19 @@ Members who are given a conditional have their Eval decision deferred, and there
 When the deadline expires, the conditional will be brought before E-Board, who will assess its completeness.
 A conditional member who does not meet these additional requirements will have failed the Eval.
 
-\asubsection{Active Membership Leave of Absence}
+\asubsection{Active Membership Co-op and Leave of Absence}
 \renewcommand{\theenumi}{\alph{enumi}} % For this section, we want items to use letters
 
 An Active Member may at any time request a Leave of Absence using the process described in \ref{Leave of Absence}.
-For the duration of an absence, a member:
+An Active Member is recognized as on co-op if they become registered for co-op by RIT.
+For the duration of an approved co-op or an approved Leave of Absence, a member:
 \begin{enumerate}
 	\item Forfeits their right to vote
 	\item Does not count towards quorum
-	\item Will not be required to attend House Meeting
+	\item Will not be required to attend House Meeting or directorship meetings
+	\item Retains Active Membership status and all other privileges under /ref{Active Membership Privileges}
 \end{enumerate}
+Exceptions may be made at the discretion of the Evaluations Director to allow a member on an approved co-op to remain unsuspended from privileges and requirements.
 
 \asubsection{Active Membership Resignations}
 An Active Member may resign by submitting, in writing, the reason for resignation to the Chair or the Evals Director.
@@ -434,9 +440,6 @@ A leave of absence can be extended by submitting a new request.
 \asubsection{Leave of Absence Return}
 A member may return from a leave of absence whichever they choose to.
 When a member wishes to return, they must in writing notify a staff member of ResLife, excluding student employees, to end their leave of absence.
-
-\asubsection{Modified Evaluations}
-A member may request their evaluation period to be extended by the duration of the leave or to end of the Standard Operating Session, whichever comes first.
 
 \asubsection{Leave of Absence for Executive Board Member}
 The duties and responsibilities of an E-Board member on leave are assumed using the process defined in \ref{Appointment of an Interim Director} until the member returns from their leave.

--- a/constitution.tex
+++ b/constitution.tex
@@ -270,7 +270,6 @@ Voting Members are expected to meet the requirements defined in \ref{Expectation
 \asubsubsection{Expectations of Active Members}
 Active Members are required to pay dues as stated in \ref{Collection of Dues}, attend all House Meetings and E-Board candidate speeches, and attend at least fifteen of the directorship meetings for each semester in which they are an Active Member and not on leave as described in /ref{Active Membership Co-op and Leave of Absence}
 They are also expected to sign a copy of the Membership Agreement.
-
 \\* \\*
 Active Members must participate in at least one major project during the academic year.
 Members are required to submit a description for this major project to E-Board for approval.
@@ -346,7 +345,7 @@ For the duration of an approved co-op or an approved Leave of Absence, a member:
 	\item Will not be required to attend House Meetings or directorship meetings
 	\item Retains Active Membership status and all other privileges under \ref{Active Membership Privileges}
 \end{enumerate}
-Exceptions may be made at the discretion of the Evaluations Director to allow a member on an approved co-op to retain privileges and requirements of Active Membership.
+Exceptions may be made at the discretion of the Evaluations Director to allow a member on an approved co-op to retain privileges and requirements of Active Membership as defined in \ref{Active Membership}.
 
 \asubsection{Active Membership Resignations}
 An Active Member may resign by submitting, in writing, the reason for resignation to the Chair or the Evals Director.

--- a/constitution.tex
+++ b/constitution.tex
@@ -265,7 +265,6 @@ Voting Members are expected to meet the requirements defined in \ref{Expectation
 Active Members are required to pay dues as stated in \ref{Collection of Dues}, attend all House Meetings and E-Board candidate speeches, and attend at least fifteen of the directorship meetings for each semester in which they are an Active Member and not on leave as described in /ref{Active Membership Co-op and Leave of Absence}
 They are also expected to sign a copy of the Membership Agreement.
 
-
 \\* \\*
 Active Members must participate in at least one major project during the academic year.
 Members are required to submit a description for this major project to E-Board for approval.
@@ -281,9 +280,6 @@ Active Members receive the privilege to:
 	\item Use CSH facilities
 	\item Receive priority for on-floor housing, or apply for On-Floor Status
 \end{enumerate}
-
-Active Members currently on co-op forfeit their right to vote on house issues, and likewise do not count towards quorum.
-Exceptions may be made at the discretion of the Evaluations Director.
 
 \asubsubsection{Expectations of Voting Members}
 \renewcommand{\theenumi}{\arabic{enumi}} % For this section, we want items to use letters

--- a/constitution.tex
+++ b/constitution.tex
@@ -343,10 +343,10 @@ For the duration of an approved co-op or an approved Leave of Absence, a member:
 \begin{enumerate}
 	\item Forfeits their right to vote
 	\item Does not count towards quorum
-	\item Will not be required to attend House Meeting or directorship meetings
-	\item Retains Active Membership status and all other privileges under /ref{Active Membership Privileges}
+	\item Will not be required to attend House Meetings or directorship meetings
+	\item Retains Active Membership status and all other privileges under \ref{Active Membership Privileges}
 \end{enumerate}
-Exceptions may be made at the discretion of the Evaluations Director to allow a member on an approved co-op to remain unsuspended from privileges and requirements.
+Exceptions may be made at the discretion of the Evaluations Director to allow a member on an approved co-op to retain privileges and requirements of Active Membership.
 
 \asubsection{Active Membership Resignations}
 An Active Member may resign by submitting, in writing, the reason for resignation to the Chair or the Evals Director.


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Active Members on Leave of Absence can not have their evaluation date modified
Active Members on co-op are not required to attend House Meeting or attend directorships or pay dues???


