### PR TITLE
Eval E-Board Exemption does not exist

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -307,7 +307,7 @@ All Active Members are expected to attend this meeting.
 
 \asubsubsubsection{Voting}
 Any Active Member who has completed all of the requirements as defined in \ref{Expectations of Active Members} at the beginning of the Membership Eval passes their Membership Eval without being voted on.
-All Active Members who have not received an exemption from E-Board prior to the Membership Eval will be evaluated on a member-by-member basis by Active Members.
+All Active Members who have not completed all of the requirements as defined in \ref{Expectations of Active Members} at the beginning of the Membership Eval will be evaluated on a member-by-member basis by Active Members.
 The Membership Eval shall hold members to the objective requirements defined in \ref{Expectations of Active Members} and determine which members may continue as an Active Member in the following academic year.
 Exceptions to the requirements may be made, as attending members may choose any of the outcomes for each member, even if the member being evaluated has not completed all of their requirements.
 These requirements must be completed before the Membership Eval occurs.

--- a/constitution.tex
+++ b/constitution.tex
@@ -313,7 +313,6 @@ All Active Members are expected to attend this meeting.
 \asubsubsubsection{Membership Evaluation Voting}
 Any Active Member who has completed all the requirements as defined in \ref{Expectations of Active Members} at the beginning of the Membership Eval passes without being voted on.
 Any Active Members who have not completed all the requirements as defined in \ref{Expectations of Active Members} at the beginning of the Membership Eval will be evaluated on a member-by-member basis by Active Members.
-
 The Membership Eval shall hold members to the objective requirements defined in \ref{Expectations of Active Members} and determine which members may continue as an Active Member in the following academic year.
 Exceptions to the requirements may be made, as attending members may choose any of the outcomes for each member, even if the member being evaluated has not completed all of their requirements.
 These requirements must be completed before the Membership Eval occurs.


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
E-Board exemptions from a membership eval does not exist nor has a process

