### PR TITLE
fix: Proper section depth for RTPs

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -775,12 +775,12 @@ Membership is composed of all RTPs.
 \asubsubsection{Qualifications of a Root Type Person}
 Candidates must be Active Members.
 
-\asubsubsection{Prior Root Type Persons}
+\asubsection{Prior Root Type Persons}
 Prior RTPs are those members who are no longer current Active Members and have not been granted an extension by the current RTPs.
 Prior RTPs are not guaranteed access to the current root passwords and other authentication tokens.
 The current RTPs may draft rules and regulations specifying the rights and privileges of Prior RTPs.
 
-\asubsubsection{Creation of Accounts}
+\asubsection{Creation of Accounts}
 RTPs have the authority to manage user accounts for CSH systems.
 Before a member may receive an account they must:
 \renewcommand{\theenumi}{\arabic{enumi}} % For this section, we want items to use letters
@@ -791,13 +791,13 @@ Before a member may receive an account they must:
 \end{enumerate}
 Accounts for Honorary and Advisory Members may be created at the discretion of the RTPs.
 
-\asubsubsection{Code of Conduct}
+\asubsection{Code of Conduct}
 The Code of Conduct located at \url{https://github.com/ComputerScienceHouse/CodeOfConduct} is the canonical Code of Conduct for CSH accounts.
 \\* \\*
 Members are bound to the Code of Conduct revision that they sign when initially creating their account.
 Members may sign a more recent revision of the Code of Conduct to update their agreement.
 
-\asubsubsubsection{Changes}
+\asubsubsection{Changes}
 \renewcommand{\theenumi}{\alph{enumi}} % For this section, we want items to use letters
 The following process is used for making changes to the Code of Conduct document.
 \begin{enumerate}


### PR DESCRIPTION
Check one:
- [ ] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

- [x] I don't know. I see it as changing bullet points (non-semantic), but maybe it is semantic? 

Summary of change(s):

Corrected the section depth for subsections within RTP definition.
