### PR TITLE
Only allow Voting Members to sign impeachment petitions

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -699,13 +699,13 @@ The vote of a vacated E-Board position shall be cast as an abstention in all E-B
 
 \asubsubsection{Impeachment}
 \begin{enumerate}
-	\item Impeachment of any E-Board Member may be initiated by petition, in writing, consisting of a minimum number of signatures of Voting Members equaling or exceeding one-third the number of Eligible Votes, as defined in \ref{Eligible Votes}.
+	\item Impeachment of any E-Board Member may be initiated by petition, in writing, consisting of a minimum number of signatures of Active Members equaling or exceeding one-third the number of Eligible Votes, as defined in \ref{Eligible Votes}.
 	\item The impeachment petition is then presented at an E-Board Meeting.
 	      The member(s) initiating the petition present their case to E-Board.
 	      E-Board then questions the accused member of the allegations.
 	\item An E-Board Vote is taken on the impeachment petition, with all Voting E-Board Members present except the accused member who must be absent and whose vote counts as an Abstention, to determine if the allegations stated in the petition are legitimate grounds for impeachment.
 	      If the majority of E-Board votes are negative, the petition and impeachment proceedings are dismissed.
-	      This vote may be overridden by an impeachment petition consisting of the grounds for impeachment and a minimum number of signatures of Voting Members equaling or exceeding two-thirds the number of Eligible Votes.
+	      This vote may be overridden by an impeachment petition consisting of the grounds for impeachment and a minimum number of signatures of Active Members equaling or exceeding two-thirds the number of Eligible Votes.
 	\item If the majority of the E-Board votes are positive, or the negative vote was overridden, the petition is presented at the following House Meeting and the accused and accuser(s) again present their cases.
 	\item Ballots will then be distributed and a Secret Ballot Vote shall be held for a minimum of a forty-eight hour period to determine whether or not the member should be removed from office.
 	      Votes shall be collected and counted for a Two-Thirds Balloted Vote, as described in \ref{Balloted Vote}.

--- a/constitution.tex
+++ b/constitution.tex
@@ -699,13 +699,13 @@ The vote of a vacated E-Board position shall be cast as an abstention in all E-B
 
 \asubsubsection{Impeachment}
 \begin{enumerate}
-	\item Impeachment of any E-Board Member may be initiated by petition, in writing, consisting of a minimum number of signatures of current members equaling or exceeding one-third the number of Eligible Votes, as defined in \ref{Eligible Votes}.
+	\item Impeachment of any E-Board Member may be initiated by petition, in writing, consisting of a minimum number of signatures of Voting Members equaling or exceeding one-third the number of Eligible Votes, as defined in \ref{Eligible Votes}.
 	\item The impeachment petition is then presented at an E-Board Meeting.
 	      The member(s) initiating the petition present their case to E-Board.
 	      E-Board then questions the accused member of the allegations.
 	\item An E-Board Vote is taken on the impeachment petition, with all Voting E-Board Members present except the accused member who must be absent and whose vote counts as an Abstention, to determine if the allegations stated in the petition are legitimate grounds for impeachment.
 	      If the majority of E-Board votes are negative, the petition and impeachment proceedings are dismissed.
-	      This vote may be overridden by an impeachment petition consisting of the grounds for impeachment and a minimum number of signatures of current members equaling or exceeding two-thirds the number of Eligible Votes.
+	      This vote may be overridden by an impeachment petition consisting of the grounds for impeachment and a minimum number of signatures of Voting Members equaling or exceeding two-thirds the number of Eligible Votes.
 	\item If the majority of the E-Board votes are positive, or the negative vote was overridden, the petition is presented at the following House Meeting and the accused and accuser(s) again present their cases.
 	\item Ballots will then be distributed and a Secret Ballot Vote shall be held for a minimum of a forty-eight hour period to determine whether or not the member should be removed from office.
 	      Votes shall be collected and counted for a Two-Thirds Balloted Vote, as described in \ref{Balloted Vote}.


### PR DESCRIPTION
Check one:
- [X] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Fix loophole, since Alumni are "current members" 
