### PR TITLE
Packet shouldnt need to start after the 1st week

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -174,10 +174,10 @@ They then undergo the selection process as defined below.
 	\item The applicant submits an application to the Evals Director for review.
 	\item The applicant participates in an informal interview with three current Active, Alumni, or Honorary Members.
 	\item The application materials are reviewed at an Evals meeting.
-	      An Immediate Relative Majority Vote of attending members is held on whether or not to accept the person as an Intro Member.
+	      Then an Immediate Relative Majority Vote of attending members is held on whether or not to accept the person as an Intro Member.
 \end{enumerate}
 
-% Incoming RIT students is defined as students who have enrolled at RIT but have not yet started taking classes
+% Incoming RIT students is defined as students who have attended RIT for less than 1 full semester
 \asubsubsection{Selection Process for Incoming RIT Students}
 \begin{enumerate}
 	\item During spring semester, the Evals Director selects a group of Active Members to form a Selections Committee.
@@ -208,7 +208,7 @@ If deemed necessary by the Evals Director or by an E-Board Vote, the second Intr
 If a second Intro Process is approved, the Evals Director may initiate a new Intro Packet within the first or second week of the process.
 
 \asubsubsection{The Introductory Packet}
-Each Intro Process participant is given two weeks to obtain signatures from all Active and Intro Members, and ten of any combination of Alumni, Honorary, and Advisory Members.
+Each Intro Process participant, after the first week, is given two weeks to obtain signatures from all Active and Intro Members, and ten of any combination of Alumni, Honorary, and Advisory Members.
 At the discretion of the Evals Director or as the result of an E-Board Vote, any Intro Packet may be extended to accommodate extenuating circumstances.
 
 \asubsubsection{Expectations of an Introductory Member}
@@ -713,7 +713,6 @@ The vote of a vacated E-Board position shall be cast as an abstention in all E-B
 	      If the resolution passes, the accused officer is relinquished of their position and any benefits thereof and this position is treated like any other vacated position.
 	      If a quorum cannot be reached after two attempts, or the percentage of affirmative votes does not equal or exceed the minimum, impeachment proceedings are dismissed.
 	      A new selection and interim duty fulfillment procedure is followed similar to that of a resignation, as described in \ref{Executive Board Resignations}.
-	\item If an impeachment petition is modified at any point after it is initiated, the petition becomes invalid.
 	\item The Secretary can be impeached according to the above process, or may be dismissed by an E-Board Vote.
 \end{enumerate}
 

--- a/constitution.tex
+++ b/constitution.tex
@@ -174,10 +174,10 @@ They then undergo the selection process as defined below.
 	\item The applicant submits an application to the Evals Director for review.
 	\item The applicant participates in an informal interview with three current Active, Alumni, or Honorary Members.
 	\item The application materials are reviewed at an Evals meeting.
-	      Then an Immediate Relative Majority Vote of attending members is held on whether or not to accept the person as an Intro Member.
+	      An Immediate Relative Majority Vote of attending members is held on whether or not to accept the person as an Intro Member.
 \end{enumerate}
 
-% Incoming RIT students is defined as students who have attended RIT for less than 1 full semester
+% Incoming RIT students is defined as students who have enrolled at RIT but have not yet started taking classes
 \asubsubsection{Selection Process for Incoming RIT Students}
 \begin{enumerate}
 	\item During spring semester, the Evals Director selects a group of Active Members to form a Selections Committee.
@@ -208,7 +208,7 @@ If deemed necessary by the Evals Director or by an E-Board Vote, the second Intr
 If a second Intro Process is approved, the Evals Director may initiate a new Intro Packet within the first or second week of the process.
 
 \asubsubsection{The Introductory Packet}
-Each Intro Process participant, after the first week, is given two weeks to obtain signatures from all Active and Intro Members, and ten of any combination of Alumni, Honorary, and Advisory Members.
+Each Intro Process participant is given two weeks to obtain signatures from all Active and Intro Members, and ten of any combination of Alumni, Honorary, and Advisory Members.
 At the discretion of the Evals Director or as the result of an E-Board Vote, any Intro Packet may be extended to accommodate extenuating circumstances.
 
 \asubsubsection{Expectations of an Introductory Member}
@@ -713,6 +713,7 @@ The vote of a vacated E-Board position shall be cast as an abstention in all E-B
 	      If the resolution passes, the accused officer is relinquished of their position and any benefits thereof and this position is treated like any other vacated position.
 	      If a quorum cannot be reached after two attempts, or the percentage of affirmative votes does not equal or exceed the minimum, impeachment proceedings are dismissed.
 	      A new selection and interim duty fulfillment procedure is followed similar to that of a resignation, as described in \ref{Executive Board Resignations}.
+	\item If an impeachment petition is modified at any point after it is initiated, the petition becomes invalid.
 	\item The Secretary can be impeached according to the above process, or may be dismissed by an E-Board Vote.
 \end{enumerate}
 

--- a/constitution.tex
+++ b/constitution.tex
@@ -208,7 +208,7 @@ If deemed necessary by the Evals Director or by an E-Board Vote, the second Intr
 If a second Intro Process is approved, the Evals Director may initiate a new Intro Packet within the first or second week of the process.
 
 \asubsubsection{The Introductory Packet}
-Each Intro Process participant, after the first week, is given two weeks to obtain signatures from all Active and Intro Members, and ten of any combination of Alumni, Honorary, and Advisory Members.
+Each Intro Process participant is given two weeks to obtain signatures from all Active and Intro Members, and ten of any combination of Alumni, Honorary, and Advisory Members.
 At the discretion of the Evals Director or as the result of an E-Board Vote, any Intro Packet may be extended to accommodate extenuating circumstances.
 
 \asubsubsection{Expectations of an Introductory Member}


### PR DESCRIPTION
Check one:
- [X] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Removed the text that says "after the first week" in the Into Packet section
