### PR TITLE
Removed quorum for cloud spending presentation votes

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -868,7 +868,7 @@ A Two-Thirds Immediate Vote with twenty-five percent quorum is required to appro
 For expenditures exceeding \$300 in total funding, a spending presentation must be presented at a House Meeting.
 This presentation includes the funds required for the expenditure, inventory of required resources, and, if applicable, a timeline for completion.
 \\* \\*
-If an appropriate directorship cannot be determined for an expenditure, it is to be brought up for approval at a House Meeting as a miscellaneous expenditure and approved by an Immediate Relative Majority vote with fifty percent quorum, regardless of the amount.
+If an appropriate directorship cannot be determined for an expenditure, it is to be brought up for approval at a House Meeting as a miscellaneous expenditure and approved by an Immediate Relative Majority vote, regardless of the amount.
 This amount is to be directly subtracted from the general CSH account.
 % HOUSING
 \asection{Housing}


### PR DESCRIPTION
We do not track quorum for cloud expenditures.

Check one:
- [X] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Removed the fifty percent quorum requirement for spending presentations that pull from "the cloud." We do not currently track quorum for this, and no other spending presentation requires a quorum.

(spotted by @pikachu0542)