### PR TITLE
Current RIT Intro Member Vote Should be Voting Members

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -175,7 +175,7 @@ They then undergo the selection process as defined below.
 	\item The applicant submits an application to the Evals Director for review.
 	\item The applicant participates in an informal interview with three current Active, Alumni, or Honorary Members.
 	\item The application materials are reviewed at an Evals meeting.
-	      Then an Immediate Relative Majority Vote of attending voting members is held on whether or not to accept the person as an Intro Member.
+	      Then an Immediate Relative Majority Vote is held on whether or not to accept the person as an Intro Member.
 \end{enumerate}
 
 % Incoming RIT students is defined as students who have attended RIT for less than 1 full semester

--- a/constitution.tex
+++ b/constitution.tex
@@ -175,7 +175,7 @@ They then undergo the selection process as defined below.
 	\item The applicant submits an application to the Evals Director for review.
 	\item The applicant participates in an informal interview with three current Active, Alumni, or Honorary Members.
 	\item The application materials are reviewed at an Evals meeting.
-	      Then an Immediate Relative Majority Vote is held on whether or not to accept the person as an Intro Member.
+	      \item An Immediate Relative Majority Vote is held to decide whether or not to accept the person as an Intro Member.
 \end{enumerate}
 
 % Incoming RIT students is defined as students who have attended RIT for less than 1 full semester

--- a/constitution.tex
+++ b/constitution.tex
@@ -175,7 +175,7 @@ They then undergo the selection process as defined below.
 	\item The applicant submits an application to the Evals Director for review.
 	\item The applicant participates in an informal interview with three current Active, Alumni, or Honorary Members.
 	\item The application materials are reviewed at an Evals meeting.
-	      Then an Immediate Relative Majority Vote of attending members is held on whether or not to accept the person as an Intro Member.
+	      Then an Immediate Relative Majority Vote of attending voting members is held on whether or not to accept the person as an Intro Member.
 \end{enumerate}
 
 % Incoming RIT students is defined as students who have attended RIT for less than 1 full semester


### PR DESCRIPTION
Check one:
- [ ] Semantic Change: something about the meaning of the text is different
- [x] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Changed vote to accept current RIT students as intro members to a vote of attending voting members