### PR TITLE
Rearranged eboard positions

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -836,9 +836,9 @@ After this date, dues collection is suspended until the start of the next academ
 		\hline
 		OpComm       & 20\%
 		\\ \hline
-		R\&D         & 20\%
-		\\ \hline
 		Social       & 20\%
+		\\ \hline
+		R\&D         & 20\%
 		\\ \hline
 		IMPs         & 15\%
 		\\ \hline

--- a/constitution.tex
+++ b/constitution.tex
@@ -508,11 +508,21 @@ A Voting E-Board Member is considered to be any E-Board Member with a non-zero v
 	\item To vote on issues presented to E-Board
 \end{enumerate}
 
-\asubsubsection{Responsibilities of the Operational Communications Director}
+\asubsubsection{Responsibilities of the Socials Director(s)}
 \begin{enumerate}
-	\item To represent the RTPs at E-Board Meetings and at House Meetings
-	\item To report the status of the house systems, services, and networks
-	\item To facilitate communications with RIT Information and Technology Services
+	\item To exercise general supervision over Social operations
+	\item To oversee the organization and execution of CSH social activities
+	\item To ensure that there is a variety of events for members to participate in throughout the academic year
+	\item To vote on issues presented to E-Board
+\end{enumerate}
+
+\asubsubsection{Responsibilities of the Public Relations Director}
+\begin{enumerate}
+	\item To operate CSH social media accounts intended to represent CSH as a whole
+	\item To oversee the organization and execution of CSH philanthropic events
+	\item To preserve and improve the public image of CSH
+	\item To collaborate with other E-Board members to organize, execute, and advertise any events that are intended to be attended by persons who have never been Active Members
+	\item To oversee the preparation of CSH for open houses, tours, and special events
 	\item To vote on issues presented to E-Board
 \end{enumerate}
 
@@ -525,19 +535,19 @@ A Voting E-Board Member is considered to be any E-Board Member with a non-zero v
 	\item To vote on issues presented to E-Board
 \end{enumerate}
 
-\asubsubsection{Responsibilities of the Socials Director(s)}
-\begin{enumerate}
-	\item To exercise general supervision over Social operations
-	\item To oversee the organization and execution of CSH social activities
-	\item To ensure that there is a variety of events for members to participate in throughout the academic year
-	\item To vote on issues presented to E-Board
-\end{enumerate}
-
 \asubsubsection{Responsibilities of the House Improvements Director}
 \begin{enumerate}
 	\item To exercise general supervision over the IMPs operations
 	\item To oversee the organization and construction of physical improvements to CSH
 	\item To oversee the general maintenance of the appearance of CSH
+	\item To vote on issues presented to E-Board
+\end{enumerate}
+
+\asubsubsection{Responsibilities of the Operational Communications Director}
+\begin{enumerate}
+	\item To represent the RTPs at E-Board Meetings and at House Meetings
+	\item To report the status of the house systems, services, and networks
+	\item To facilitate communications with RIT Information and Technology Services
 	\item To vote on issues presented to E-Board
 \end{enumerate}
 
@@ -547,16 +557,6 @@ A Voting E-Board Member is considered to be any E-Board Member with a non-zero v
 	\item To maintain, uphold, and promote house traditions
 	\item To collaborate with the Social Director(s) to ensure that all the Active, Alumni, and Advisory Members are informed of upcoming events
 	\item To oversee the production and distribution of a semi-annual newsletter
-	\item To vote on issues presented to E-Board
-\end{enumerate}
-
-\asubsubsection{Responsibilities of the Public Relations Director}
-\begin{enumerate}
-	\item To operate CSH social media accounts intended to represent CSH as a whole
-	\item To oversee the organization and execution of CSH philanthropic events
-	\item To preserve and improve the public image of CSH
-	\item To collaborate with other E-Board members to organize, execute, and advertise any events that are intended to be attended by persons who have never been Active Members
-	\item To oversee the preparation of CSH for open houses, tours, and special events
 	\item To vote on issues presented to E-Board
 \end{enumerate}
 
@@ -587,7 +587,7 @@ However, the Chair and at least two-thirds of the Voting Members of E-Board must
 	\item Candidates must be enrolled students at RIT, must be in good academic standing with both RIT and their academic department, and may not be on a conduct sanction of disciplinary probation or higher during the term of office.
 \end{enumerate}
 
-\asubsubsection{Qualifications for Chairperson, Evaluations Director, Financial Director, Research and Development Director(s), Social Director(s), House Improvements Director, History Director, Public Relations Director}
+\asubsubsection{Qualifications for Chairperson, Evaluations Director, Financial Director, Social Director, Research and Development Director(s), House Improvements Director, History Director, Public Relations Director}
 \begin{enumerate}
 	\item Elected or selected candidates may not hold two simultaneous voting E-Board positions, and must therefore resign their current position or decline a second position should they be elected or selected to a second voting position.
 	\item Candidates for Chair or Evals Director must reside on floor during the term of office.
@@ -631,7 +631,7 @@ The following special cases cover the operation of dual directors:
 	      When attendance requirements call for the dual directorship position to be present, at least one of the dual directors must be present to fulfill the requirements.
 \end{enumerate}
 
-\asubsubsection{Selection of the Chairperson, Evaluations Director, Financial Director, Research and Development Director(s), Social Director(s), House Improvements Director, History Director, Public Relations Director}
+\asubsubsection{Selection of the Chairperson, Evaluations Director, Financial Director, Social Director(s), House Improvements Director, History Director,  Research and Development Director(s), Public Relations Director}
 \begin{enumerate}
 	\item The opening of the E-Board position(s) is announced at a House Meeting and nominations for the position are taken for a minimum of a seventy-two hour period.
 	      Any member may nominate any member, or pair of members where appropriate, for a directorship.

--- a/constitution.tex
+++ b/constitution.tex
@@ -836,9 +836,9 @@ After this date, dues collection is suspended until the start of the next academ
 		\hline
 		OpComm       & 20\%
 		\\ \hline
-		Social       & 20\%
-		\\ \hline
 		R\&D         & 20\%
+		\\ \hline
+		Social       & 20\%
 		\\ \hline
 		IMPs         & 15\%
 		\\ \hline

--- a/constitution.tex
+++ b/constitution.tex
@@ -516,16 +516,6 @@ A Voting E-Board Member is considered to be any E-Board Member with a non-zero v
 	\item To vote on issues presented to E-Board
 \end{enumerate}
 
-\asubsubsection{Responsibilities of the Public Relations Director}
-\begin{enumerate}
-	\item To operate CSH social media accounts intended to represent CSH as a whole
-	\item To oversee the organization and execution of CSH philanthropic events
-	\item To preserve and improve the public image of CSH
-	\item To collaborate with other E-Board members to organize, execute, and advertise any events that are intended to be attended by persons who have never been Active Members
-	\item To oversee the preparation of CSH for open houses, tours, and special events
-	\item To vote on issues presented to E-Board
-\end{enumerate}
-
 \asubsubsection{Responsibilities of the Research and Development Director(s)}
 \begin{enumerate}
 	\item To exercise general supervision over R\&D operations
@@ -557,6 +547,16 @@ A Voting E-Board Member is considered to be any E-Board Member with a non-zero v
 	\item To maintain, uphold, and promote house traditions
 	\item To collaborate with the Social Director(s) to ensure that all the Active, Alumni, and Advisory Members are informed of upcoming events
 	\item To oversee the production and distribution of a semi-annual newsletter
+	\item To vote on issues presented to E-Board
+\end{enumerate}
+
+\asubsubsection{Responsibilities of the Public Relations Director}
+\begin{enumerate}
+	\item To operate CSH social media accounts intended to represent CSH as a whole
+	\item To oversee the organization and execution of CSH philanthropic events
+	\item To preserve and improve the public image of CSH
+	\item To collaborate with other E-Board members to organize, execute, and advertise any events that are intended to be attended by persons who have never been Active Members
+	\item To oversee the preparation of CSH for open houses, tours, and special events
 	\item To vote on issues presented to E-Board
 \end{enumerate}
 

--- a/constitution.tex
+++ b/constitution.tex
@@ -496,24 +496,6 @@ A Voting E-Board Member is considered to be any E-Board Member with a non-zero v
 	\item To vote on issues presented to E-Board
 \end{enumerate}
 
-\asubsubsection{Responsibilities of the Socials Director(s)}
-\begin{enumerate}
-	\item To exercise general supervision over Social operations
-	\item To oversee the organization and execution of CSH social activities
-	\item To ensure that there is a variety of events for members to participate in throughout the academic year
-	\item To vote on issues presented to E-Board
-\end{enumerate}
-
-\asubsubsection{Responsibilities of the Public Relations Director}
-\begin{enumerate}
-	\item To operate CSH social media accounts intended to represent CSH as a whole
-	\item To oversee the organization and execution of CSH philanthropic events
-	\item To preserve and improve the public image of CSH
-	\item To collaborate with other E-Board members to organize, execute, and advertise any events that are intended to be attended by persons who have never been Active Members
-	\item To oversee the preparation of CSH for open houses, tours, and special events
-	\item To vote on issues presented to E-Board
-\end{enumerate}
-
 \asubsubsection{Responsibilities of the Financial Director}
 \begin{enumerate}
 	\item To supervise financial administrators and transactions involving house projects
@@ -526,12 +508,28 @@ A Voting E-Board Member is considered to be any E-Board Member with a non-zero v
 	\item To vote on issues presented to E-Board
 \end{enumerate}
 
+\asubsubsection{Responsibilities of the Operational Communications Director}
+\begin{enumerate}
+	\item To represent the RTPs at E-Board Meetings and at House Meetings
+	\item To report the status of the house systems, services, and networks
+	\item To facilitate communications with RIT Information and Technology Services
+	\item To vote on issues presented to E-Board
+\end{enumerate}
+
 \asubsubsection{Responsibilities of the Research and Development Director(s)}
 \begin{enumerate}
 	\item To exercise general supervision over R\&D operations
 	\item To oversee the planning, organization, and construction of technical projects for the CSH's benefit
 	\item To strive to fulfill the CSH's need for technical equipment
 	\item To organize, support, and approve Technical Seminars
+	\item To vote on issues presented to E-Board
+\end{enumerate}
+
+\asubsubsection{Responsibilities of the Socials Director(s)}
+\begin{enumerate}
+	\item To exercise general supervision over Social operations
+	\item To oversee the organization and execution of CSH social activities
+	\item To ensure that there is a variety of events for members to participate in throughout the academic year
 	\item To vote on issues presented to E-Board
 \end{enumerate}
 
@@ -543,20 +541,22 @@ A Voting E-Board Member is considered to be any E-Board Member with a non-zero v
 	\item To vote on issues presented to E-Board
 \end{enumerate}
 
-\asubsubsection{Responsibilities of the Operational Communications Director}
-\begin{enumerate}
-	\item To represent the RTPs at E-Board Meetings and at House Meetings
-	\item To report the status of the house systems, services, and networks
-	\item To facilitate communications with RIT Information and Technology Services
-	\item To vote on issues presented to E-Board
-\end{enumerate}
-
 \asubsubsection{Responsibilities of the History Director}
 \begin{enumerate}
 	\item To exercise general supervision over the History operations
 	\item To maintain, uphold, and promote house traditions
 	\item To collaborate with the Social Director(s) to ensure that all the Active, Alumni, and Advisory Members are informed of upcoming events
 	\item To oversee the production and distribution of a semi-annual newsletter
+	\item To vote on issues presented to E-Board
+\end{enumerate}
+
+\asubsubsection{Responsibilities of the Public Relations Director}
+\begin{enumerate}
+	\item To operate CSH social media accounts intended to represent CSH as a whole
+	\item To oversee the organization and execution of CSH philanthropic events
+	\item To preserve and improve the public image of CSH
+	\item To collaborate with other E-Board members to organize, execute, and advertise any events that are intended to be attended by persons who have never been Active Members
+	\item To oversee the preparation of CSH for open houses, tours, and special events
 	\item To vote on issues presented to E-Board
 \end{enumerate}
 
@@ -587,7 +587,7 @@ However, the Chair and at least two-thirds of the Voting Members of E-Board must
 	\item Candidates must be enrolled students at RIT, must be in good academic standing with both RIT and their academic department, and may not be on a conduct sanction of disciplinary probation or higher during the term of office.
 \end{enumerate}
 
-\asubsubsection{Qualifications for Chairperson, Evaluations Director, Social Director, Financial Director, Research and Development Director(s), House Improvements Director, History Director, Public Relations Director}
+\asubsubsection{Qualifications for Chairperson, Evaluations Director, Financial Director, Research and Development Director(s), Social Director(s), House Improvements Director, History Director, Public Relations Director}
 \begin{enumerate}
 	\item Elected or selected candidates may not hold two simultaneous voting E-Board positions, and must therefore resign their current position or decline a second position should they be elected or selected to a second voting position.
 	\item Candidates for Chair or Evals Director must reside on floor during the term of office.
@@ -631,7 +631,7 @@ The following special cases cover the operation of dual directors:
 	      When attendance requirements call for the dual directorship position to be present, at least one of the dual directors must be present to fulfill the requirements.
 \end{enumerate}
 
-\asubsubsection{Selection of the Chairperson, Evaluations Director, Social Director(s), Financial Director, House Improvements Director, History Director,  Research and Development Director(s), Public Relations Director}
+\asubsubsection{Selection of the Chairperson, Evaluations Director, Financial Director, Research and Development Director(s), Social Director(s), House Improvements Director, History Director, Public Relations Director}
 \begin{enumerate}
 	\item The opening of the E-Board position(s) is announced at a House Meeting and nominations for the position are taken for a minimum of a seventy-two hour period.
 	      Any member may nominate any member, or pair of members where appropriate, for a directorship.

--- a/constitution.tex
+++ b/constitution.tex
@@ -587,7 +587,7 @@ However, the Chair and at least two-thirds of the Voting Members of E-Board must
 	\item Candidates must be enrolled students at RIT, must be in good academic standing with both RIT and their academic department, and may not be on a conduct sanction of disciplinary probation or higher during the term of office.
 \end{enumerate}
 
-\asubsubsection{Qualifications for Chairperson, Evaluations Director, Financial Director, Social Director, Research and Development Director(s), House Improvements Director, History Director, Public Relations Director}
+\asubsubsection{Qualifications for Chairperson, Evaluations Director, Financial Director, Social Director(s), Research and Development Director(s), House Improvements Director, History Director, Public Relations Director}
 \begin{enumerate}
 	\item Elected or selected candidates may not hold two simultaneous voting E-Board positions, and must therefore resign their current position or decline a second position should they be elected or selected to a second voting position.
 	\item Candidates for Chair or Evals Director must reside on floor during the term of office.


### PR DESCRIPTION
Check one:
- [ ] Semantic Change: something about the meaning of the text is different
- [x] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Rearranged eboard positions to be: chair, evals, financials, socials, rnd, imps, opcomm, history, PR. 