### PR TITLE
Remove on floor status from the constitution 

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -184,6 +184,7 @@ They then undergo the selection process as defined below.
 	\item During spring semester, the Evals Director selects a group of Active Members to form a Selections Committee.
 	      The Selections Committee reviews applications in accordance with the process prescribed by ResLife.
 	\item A subset of applicants will be offered Intro Membership and have the opportunity to participate in the Intro Process defined in \ref{The Evaluation Period}.
+	\item A subset of Intro Members will be able to select a room on-floor. The other Intro Members not live on-floor, but will otherwise have the same privileges and responsibilities
 \end{enumerate}
 
 \asubsection{Introductory Membership Expectations}
@@ -260,7 +261,7 @@ Alumni Members in good standing may self-select into Active Membership by paying
 \\*\\*
 Any Alumni Member in bad standing, as described in \ref{Alumni Membership Selection}, may become an Active Member by notifying the Evals Director of their intent to participate.
 The Evals Director will then bring them up for an Immediate Relative Majority vote with fifty percent quorum at the next House Meeting.
-If the vote passes, the Alumni is reinstated as an Active Member with zero Housing Priority Points effective immediately.
+If the vote passes, the Alumni is reinstated as an Active Member effective immediately.
 
 \asubsection{Active Membership Expectations}
 Active Members are expected to be active participants in CSH as defined in \ref{Expectations of Active Members}.
@@ -875,8 +876,7 @@ This amount is to be directly subtracted from the general CSH account.
 \asubsection{Housing Status}
 All Alumni, Active, and Intro Members have a Housing Status.
 This status indicates their privilege of priority housing on the floor.
-Alumni Members in good standing keep the housing status they had as Active Members.
-Alumni Members in bad standing lose any Housing Priority Points they had accumulated.
+Alumni Members keep any Housing Priority Points they had as Active Members.
 
 \asubsection{Housing Priority System}
 The Housing Priority System is a means for determining the priority a member has in a housing issue or the assignment of available housing.

--- a/constitution.tex
+++ b/constitution.tex
@@ -184,7 +184,7 @@ They then undergo the selection process as defined below.
 	\item During spring semester, the Evals Director selects a group of Active Members to form a Selections Committee.
 	      The Selections Committee reviews applications in accordance with the process prescribed by ResLife.
 	\item A subset of applicants will be offered Intro Membership and have the opportunity to participate in the Intro Process defined in \ref{The Evaluation Period}.
-	\item A subset of Intro Members will be able to select a room on-floor. The other Intro Members not live on-floor, but will otherwise have the same privileges and responsibilities
+	\item A subset of Intro Members will be able to select a room on-floor. The other Intro Members will not live on-floor, but will otherwise have the same privileges and responsibilities.
 \end{enumerate}
 
 \asubsection{Introductory Membership Expectations}

--- a/constitution.tex
+++ b/constitution.tex
@@ -184,8 +184,6 @@ They then undergo the selection process as defined below.
 	\item During spring semester, the Evals Director selects a group of Active Members to form a Selections Committee.
 	      The Selections Committee reviews applications in accordance with the process prescribed by ResLife.
 	\item A subset of applicants will be offered Intro Membership and have the opportunity to participate in the Intro Process defined in \ref{The Evaluation Period}.
-	      A subset of Intro Members will be offered On-Floor status and will be able to select a room on floor.
-	      The other Intro Members will have Off-Floor status, but will otherwise have the same privileges and responsibilities.
 \end{enumerate}
 
 \asubsection{Introductory Membership Expectations}
@@ -262,7 +260,7 @@ Alumni Members in good standing may self-select into Active Membership by paying
 \\*\\*
 Any Alumni Member in bad standing, as described in \ref{Alumni Membership Selection}, may become an Active Member by notifying the Evals Director of their intent to participate.
 The Evals Director will then bring them up for an Immediate Relative Majority vote with fifty percent quorum at the next House Meeting.
-If the vote passes, the Alumni is reinstated as an Active Member with Off-Floor Status effective immediately.
+If the vote passes, the Alumni is reinstated as an Active Member with zero Housing Priority Points effective immediately.
 
 \asubsection{Active Membership Expectations}
 Active Members are expected to be active participants in CSH as defined in \ref{Expectations of Active Members}.
@@ -284,7 +282,7 @@ Active Members receive the privilege to:
 	\item Vote on CSH issues
 	\item Hold a position on E-Board
 	\item Use CSH facilities
-	\item Receive priority for on-floor housing, or apply for On-Floor Status
+	\item Receive priority for on-floor housing
 \end{enumerate}
 
 \asubsubsection{Expectations of Voting Members}
@@ -878,20 +876,11 @@ This amount is to be directly subtracted from the general CSH account.
 All Alumni, Active, and Intro Members have a Housing Status.
 This status indicates their privilege of priority housing on the floor.
 Alumni Members in good standing keep the housing status they had as Active Members.
-Alumni Members in bad standing have Off-Floor Status.
-
-\asubsubsection{On-Floor Status}
-Members with On-Floor Status are eligible to live on the floor.
-To be granted On-Floor Status, members may notify the Evals Director that they would like to come up for a vote.
-The Evals Director will then bring them up for vote at the next Evals Meeting.
-
-\asubsubsection{Off-Floor Status}
-Members with Off-Floor Status do not have the right to live on the floor.
-They still have access to all other privileges associated with their membership, and may still accumulate Housing Priority Points.
+Alumni Members in bad standing lose any Housing Priority Points they had accumulated.
 
 \asubsection{Housing Priority System}
 The Housing Priority System is a means for determining the priority a member has in a housing issue or the assignment of available housing.
-The member with top priority is the member with On-Floor Status and the most Housing Priority Points.
+The member with top priority is the member with the most Housing Priority Points.
 Housing Priority Points are accumulated once per Operating Session at the conclusion of the Membership Eval.
 Each Active Member who passes the Membership Eval is granted two Housing Priority Points.
 

--- a/constitution.tex
+++ b/constitution.tex
@@ -257,7 +257,7 @@ Intro Membership shall last until the end of the Intro Process, at which time Ac
 Active Membership is open to all students currently enrolled at RIT who have passed the Intro Eval and their most recent Membership Eval.
 
 \asubsection{Active Membership Selection}
-Alumni Members in good standing may self-select into Active Membership by paying dues to the Financial Director and notifying the Evals Director. They will retain their previous Housing Status if applicable.
+Alumni Members in good standing may self-select into Active Membership by paying dues to the Financial Director and notifying the Evals Director. They will retain their previous Housing Priority Points if applicable.
 \\*\\*
 Any Alumni Member in bad standing, as described in \ref{Alumni Membership Selection}, may become an Active Member by notifying the Evals Director of their intent to participate.
 The Evals Director will then bring them up for an Immediate Relative Majority vote with fifty percent quorum at the next House Meeting.
@@ -873,16 +873,12 @@ This amount is to be directly subtracted from the general CSH account.
 % HOUSING
 \asection{Housing}
 
-\asubsection{Housing Status}
-All Alumni, Active, and Intro Members have a Housing Status.
-This status indicates their privilege of priority housing on the floor.
-Alumni Members keep any Housing Priority Points they had as Active Members.
-
 \asubsection{Housing Priority System}
 The Housing Priority System is a means for determining the priority a member has in a housing issue or the assignment of available housing.
 The member with top priority is the member with the most Housing Priority Points.
 Housing Priority Points are accumulated once per Operating Session at the conclusion of the Membership Eval.
 Each Active Member who passes the Membership Eval is granted two Housing Priority Points.
+Alumni Members keep any Housing Priority Points they had as Active Members.
 
 \asection{Evaluations Processes}
 At the beginning of any Eval Process, the Evals Director must read the sections of the CSH Constitution regarding the relevant Eval Process.


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Bye bye on floor status!
